### PR TITLE
feat: note memory end-to-end with multi-image support

### DIFF
--- a/src/app/components/AddMemoryScreen.tsx
+++ b/src/app/components/AddMemoryScreen.tsx
@@ -1,31 +1,23 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 import { motion } from 'motion/react';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, X } from 'lucide-react';
 import { getLocations } from '../../lib/locationService';
-import { createPhotoMemory } from '../../lib/memoryService';
+import { createPhotoMemory, createNoteMemory } from '../../lib/memoryService';
 import type { Location } from '../../lib/types';
 
 type MemoryType = 'photo' | 'note' | 'book';
+type NoteSubtype = 'text' | 'handwritten';
 
 const inputStyle: React.CSSProperties = {
-  width: '100%',
-  padding: '10px 0',
-  background: 'transparent',
-  border: 'none',
-  borderBottom: '1px solid var(--ink-faint)',
-  color: 'var(--ink-text)',
-  fontSize: '0.9rem',
-  fontFamily: 'var(--font-serif)',
-  outline: 'none',
+  width: '100%', padding: '10px 0', background: 'transparent', border: 'none',
+  borderBottom: '1px solid var(--ink-faint)', color: 'var(--ink-text)',
+  fontSize: '0.9rem', fontFamily: 'var(--font-serif)', outline: 'none',
 };
 
 const labelStyle: React.CSSProperties = {
-  color: 'var(--ink-light)',
-  fontSize: '0.75rem',
-  display: 'block',
-  marginBottom: '6px',
-  letterSpacing: '0.05em',
+  color: 'var(--ink-light)', fontSize: '0.75rem', display: 'block',
+  marginBottom: '6px', letterSpacing: '0.05em',
 };
 
 export function AddMemoryScreen() {
@@ -34,12 +26,14 @@ export function AddMemoryScreen() {
   const preselectedLocationId = searchParams.get('locationId') ?? '';
 
   const [type, setType] = useState<MemoryType>('photo');
+  const [noteSubtype, setNoteSubtype] = useState<NoteSubtype>('text');
   const [locations, setLocations] = useState<Location[]>([]);
   const [locationId, setLocationId] = useState(preselectedLocationId);
   const [date, setDate] = useState(new Date().toISOString().slice(0, 10));
-  const [imageFile, setImageFile] = useState<File | null>(null);
-  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [imageFiles, setImageFiles] = useState<File[]>([]);
+  const [imagePreviews, setImagePreviews] = useState<string[]>([]);
   const [caption, setCaption] = useState('');
+  const [noteContent, setNoteContent] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -48,211 +42,163 @@ export function AddMemoryScreen() {
     getLocations().then(setLocations).catch(console.error);
   }, []);
 
+  useEffect(() => {
+    setImageFiles([]);
+    setImagePreviews([]);
+    setCaption('');
+    setNoteContent('');
+    setError('');
+  }, [type, noteSubtype]);
+
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setImageFile(file);
-    setImagePreview(URL.createObjectURL(file));
+    const files = Array.from(e.target.files ?? []);
+    if (!files.length) return;
+    setImageFiles((prev) => [...prev, ...files]);
+    setImagePreviews((prev) => [...prev, ...files.map((f) => URL.createObjectURL(f))]);
+    e.target.value = '';
+  }
+
+  function removeImage(index: number) {
+    setImageFiles((prev) => prev.filter((_, i) => i !== index));
+    setImagePreviews((prev) => prev.filter((_, i) => i !== index));
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!locationId) { setError('请选择地点'); return; }
     if (!date) { setError('请选择日期'); return; }
-    if (type === 'photo' && !imageFile) { setError('请上传照片'); return; }
+    if (type === 'photo' && imageFiles.length === 0) { setError('请至少上传一张照片'); return; }
+    if (type === 'note' && noteSubtype === 'handwritten' && imageFiles.length === 0) { setError('请至少上传一张手写笔记图片'); return; }
+    if (type === 'note' && noteSubtype === 'text' && !noteContent.trim()) { setError('请输入笔记内容'); return; }
 
     setSaving(true);
     setError('');
     try {
-      if (type === 'photo' && imageFile) {
-        await createPhotoMemory(locationId, date, imageFile, caption || undefined);
-        navigate(`/location/${locationId}`);
+      if (type === 'photo') {
+        await createPhotoMemory(locationId, date, imageFiles, caption || undefined);
+      } else if (type === 'note') {
+        await createNoteMemory(locationId, date, noteSubtype, noteContent || undefined, imageFiles.length > 0 ? imageFiles : undefined);
       }
+      navigate(`/location/${locationId}`);
     } catch (err: any) {
-      const msg = err?.message || err?.error_description || JSON.stringify(err);
-      setError(`保存失败：${msg}`);
+      setError(`保存失败：${err?.message || JSON.stringify(err)}`);
       console.error(err);
     } finally {
       setSaving(false);
     }
   }
 
-  const types: { key: MemoryType; label: string; enabled: boolean }[] = [
-    { key: 'photo', label: '照片', enabled: true },
-    { key: 'note', label: '笔记', enabled: false },
-    { key: 'book', label: '书籍', enabled: false },
-  ];
+  const showImageUpload = type === 'photo' || (type === 'note' && noteSubtype === 'handwritten');
 
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: 0.8 }}
-      className="min-h-screen p-6"
-      style={{ fontFamily: 'var(--font-serif)' }}
-    >
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.8 }} className="min-h-screen p-6" style={{ fontFamily: 'var(--font-serif)' }}>
       <div className="max-w-md mx-auto">
         {/* Header */}
         <div className="mb-10">
-          <Link
-            to={locationId ? `/location/${locationId}` : '/'}
-            style={{ color: 'var(--ink-light)', fontSize: '0.875rem' }}
-            className="inline-flex items-center gap-2 mb-6 hover:opacity-70 transition-opacity"
-          >
-            <ArrowLeft size={16} />
-            返回
+          <Link to={locationId ? `/location/${locationId}` : '/'} style={{ color: 'var(--ink-light)', fontSize: '0.875rem' }} className="inline-flex items-center gap-2 mb-6 hover:opacity-70 transition-opacity">
+            <ArrowLeft size={16} /> 返回
           </Link>
-
-          <motion.h2
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.2, duration: 0.8 }}
-            style={{ color: 'var(--ink-text)', fontSize: '1.5rem', fontWeight: 400, letterSpacing: '0.02em' }}
-          >
+          <motion.h2 initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2, duration: 0.8 }} style={{ color: 'var(--ink-text)', fontSize: '1.5rem', fontWeight: 400, letterSpacing: '0.02em' }}>
             添加記憶
           </motion.h2>
         </div>
 
         {/* Type tabs */}
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.3, duration: 0.6 }}
-          className="flex gap-6 mb-10"
-        >
-          {types.map(({ key, label, enabled }) => (
-            <button
-              key={key}
-              onClick={() => enabled && setType(key)}
-              disabled={!enabled}
-              style={{
-                background: 'none',
-                border: 'none',
-                cursor: enabled ? 'pointer' : 'default',
-                fontFamily: 'var(--font-serif)',
-                fontSize: '0.875rem',
-                color: !enabled ? 'var(--ink-faint)' : type === key ? 'var(--ink-text)' : 'var(--ink-light)',
-                paddingBottom: '4px',
-                borderBottom: type === key && enabled ? '1px solid var(--ink-text)' : 'none',
-                transition: 'all 0.2s',
-              }}
-            >
+        <div className="flex gap-6 mb-8">
+          {([{ key: 'photo', label: '照片', enabled: true }, { key: 'note', label: '笔记', enabled: true }, { key: 'book', label: '书籍', enabled: false }] as const).map(({ key, label, enabled }) => (
+            <button key={key} onClick={() => enabled && setType(key as MemoryType)} disabled={!enabled} style={{ background: 'none', border: 'none', cursor: enabled ? 'pointer' : 'default', fontFamily: 'var(--font-serif)', fontSize: '0.875rem', color: !enabled ? 'var(--ink-faint)' : type === key ? 'var(--ink-text)' : 'var(--ink-light)', paddingBottom: '4px', borderBottom: type === key && enabled ? '1px solid var(--ink-text)' : 'none', transition: 'all 0.2s' }}>
               {label}
             </button>
           ))}
-        </motion.div>
+        </div>
 
-        {/* Form */}
-        <motion.form
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.4, duration: 0.6 }}
-          onSubmit={handleSubmit}
-          className="space-y-8"
-        >
-          {/* Image upload */}
-          <div>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              onChange={handleFileChange}
-              className="hidden"
-            />
-            {imagePreview ? (
-              <div
-                className="relative cursor-pointer overflow-hidden"
-                style={{ boxShadow: '0 2px 8px var(--paper-shadow)' }}
-                onClick={() => fileInputRef.current?.click()}
-              >
-                <img
-                  src={imagePreview}
-                  alt="preview"
-                  className="w-full"
-                  style={{ maxHeight: '320px', objectFit: 'cover', filter: 'contrast(0.92) saturate(0.85)' }}
-                />
-                <div
-                  className="absolute inset-0 flex items-center justify-center opacity-0 hover:opacity-100 transition-opacity"
-                  style={{ background: 'rgba(248,246,241,0.75)', fontSize: '0.8rem', color: 'var(--ink-light)' }}
-                >
-                  点击更换
+        {/* Note subtype */}
+        {type === 'note' && (
+          <div className="flex gap-4 mb-8">
+            {(['text', 'handwritten'] as NoteSubtype[]).map((sub) => (
+              <button key={sub} onClick={() => setNoteSubtype(sub)} style={{ background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'var(--font-serif)', fontSize: '0.8rem', color: noteSubtype === sub ? 'var(--ink-text)' : 'var(--ink-faint)', paddingBottom: '2px', borderBottom: noteSubtype === sub ? '1px solid var(--ink-faint)' : 'none' }}>
+                {sub === 'text' ? '文字' : '手写'}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-8">
+          {/* Image upload area */}
+          {showImageUpload && (
+            <div>
+              <input ref={fileInputRef} type="file" accept="image/*" multiple onChange={handleFileChange} className="hidden" />
+
+              {/* Previews grid */}
+              {imagePreviews.length > 0 && (
+                <div className="grid grid-cols-3 gap-2 mb-3">
+                  {imagePreviews.map((src, i) => (
+                    <div key={i} className="relative" style={{ aspectRatio: '1', overflow: 'hidden' }}>
+                      <img src={src} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover', filter: 'contrast(0.92) saturate(0.85)' }} />
+                      <button type="button" onClick={() => removeImage(i)} style={{ position: 'absolute', top: '4px', right: '4px', background: 'rgba(58,54,50,0.6)', border: 'none', borderRadius: '50%', width: '20px', height: '20px', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 0 }}>
+                        <X size={12} color="white" />
+                      </button>
+                    </div>
+                  ))}
                 </div>
-              </div>
-            ) : (
-              <div
-                className="flex items-center justify-center cursor-pointer transition-opacity hover:opacity-70"
-                style={{ height: '200px', border: '1px dashed var(--ink-faint)', background: 'var(--paper-warm)' }}
-                onClick={() => fileInputRef.current?.click()}
-              >
-                <span style={{ color: 'var(--ink-faint)', fontSize: '0.875rem' }}>点击上传照片</span>
-              </div>
-            )}
-          </div>
+              )}
 
-          {/* Caption */}
-          <div>
-            <label style={labelStyle}>备注（可选）</label>
-            <input
-              type="text"
-              value={caption}
-              onChange={(e) => setCaption(e.target.value)}
-              placeholder="写点什么…"
-              style={inputStyle}
-            />
-          </div>
+              {/* Add more / first upload button */}
+              <div className="flex items-center justify-center cursor-pointer transition-opacity hover:opacity-70" style={{ height: imagePreviews.length > 0 ? '48px' : '180px', border: '1px dashed var(--ink-faint)', background: 'var(--paper-warm)' }} onClick={() => fileInputRef.current?.click()}>
+                <span style={{ color: 'var(--ink-faint)', fontSize: '0.8rem' }}>
+                  {imagePreviews.length > 0 ? '+ 继续添加' : type === 'photo' ? '点击上传照片（可多选）' : '上传手写笔记照片（可多选）'}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* Photo caption */}
+          {type === 'photo' && (
+            <div>
+              <label style={labelStyle}>备注（可选）</label>
+              <input type="text" value={caption} onChange={(e) => setCaption(e.target.value)} placeholder="写点什么…" style={inputStyle} />
+            </div>
+          )}
+
+          {/* Note text */}
+          {type === 'note' && noteSubtype === 'text' && (
+            <div>
+              <label style={labelStyle}>笔记内容</label>
+              <textarea value={noteContent} onChange={(e) => setNoteContent(e.target.value)} placeholder="写下当时的想法…" rows={8} style={{ ...inputStyle, borderBottom: 'none', border: '1px solid var(--ink-faint)', padding: '12px', resize: 'vertical', lineHeight: '1.8' }} />
+            </div>
+          )}
+
+          {/* Handwritten annotation */}
+          {type === 'note' && noteSubtype === 'handwritten' && (
+            <div>
+              <label style={labelStyle}>标注（可选）</label>
+              <input type="text" value={noteContent} onChange={(e) => setNoteContent(e.target.value)} placeholder="补充一点文字…" style={inputStyle} />
+            </div>
+          )}
 
           {/* Location */}
           <div>
             <label style={labelStyle}>地点</label>
-            <select
-              value={locationId}
-              onChange={(e) => setLocationId(e.target.value)}
-              style={{ ...inputStyle, cursor: 'pointer' }}
-            >
+            <select value={locationId} onChange={(e) => setLocationId(e.target.value)} style={{ ...inputStyle, cursor: 'pointer' }}>
               <option value="">选择地点</option>
-              {locations.map((l) => (
-                <option key={l.id} value={l.id}>{l.name}</option>
-              ))}
+              {locations.map((l) => <option key={l.id} value={l.id}>{l.name}</option>)}
             </select>
           </div>
 
           {/* Date */}
           <div>
             <label style={labelStyle}>日期</label>
-            <input
-              type="date"
-              value={date}
-              onChange={(e) => setDate(e.target.value)}
-              style={inputStyle}
-            />
+            <input type="date" value={date} onChange={(e) => setDate(e.target.value)} style={inputStyle} />
           </div>
 
-          {/* Error */}
-          {error && (
-            <p style={{ color: 'var(--ink-light)', fontSize: '0.8rem' }}>{error}</p>
-          )}
+          {error && <p style={{ color: 'var(--ink-light)', fontSize: '0.8rem' }}>{error}</p>}
 
-          {/* Submit */}
           <div className="pt-4">
-            <button
-              type="submit"
-              disabled={saving}
-              style={{
-                width: '100%',
-                padding: '14px',
-                background: 'var(--ink-text)',
-                color: 'var(--paper-warm)',
-                fontSize: '0.875rem',
-                fontFamily: 'var(--font-serif)',
-                border: 'none',
-                cursor: saving ? 'default' : 'pointer',
-                opacity: saving ? 0.6 : 1,
-              }}
-            >
+            <button type="submit" disabled={saving} style={{ width: '100%', padding: '14px', background: 'var(--ink-text)', color: 'var(--paper-warm)', fontSize: '0.875rem', fontFamily: 'var(--font-serif)', border: 'none', cursor: saving ? 'default' : 'pointer', opacity: saving ? 0.6 : 1 }}>
               {saving ? '保存中…' : '保存記憶'}
             </button>
           </div>
-        </motion.form>
+        </form>
       </div>
     </motion.div>
   );

--- a/src/app/components/LocationMemoryScreen.tsx
+++ b/src/app/components/LocationMemoryScreen.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft } from 'lucide-react';
 import { getLocationById } from '../../lib/locationService';
 import { getMemoriesByLocation } from '../../lib/memoryService';
 import { getMemoryLayout } from '../../lib/pseudoRandom';
+import { StackedImages } from './StackedImages';
 import type { Location, Memory } from '../../lib/types';
 
 export function LocationMemoryScreen() {
@@ -26,53 +27,28 @@ export function LocationMemoryScreen() {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center" style={{ fontFamily: 'var(--font-serif)', color: 'var(--ink-faint)', fontSize: '0.875rem' }}>
-        …
-      </div>
+      <div className="min-h-screen flex items-center justify-center" style={{ fontFamily: 'var(--font-serif)', color: 'var(--ink-faint)', fontSize: '0.875rem' }}>…</div>
     );
   }
 
   if (!location) {
     return (
-      <div className="min-h-screen flex items-center justify-center" style={{ fontFamily: 'var(--font-serif)', color: 'var(--ink-faint)', fontSize: '0.875rem' }}>
-        找不到这个地点
-      </div>
+      <div className="min-h-screen flex items-center justify-center" style={{ fontFamily: 'var(--font-serif)', color: 'var(--ink-faint)', fontSize: '0.875rem' }}>找不到这个地点</div>
     );
   }
 
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: 0.8 }}
-      className="min-h-screen p-6"
-      style={{ fontFamily: 'var(--font-serif)' }}
-    >
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.8 }} className="min-h-screen p-6" style={{ fontFamily: 'var(--font-serif)' }}>
       {/* Header */}
       <div className="max-w-4xl mx-auto mb-12">
-        <Link
-          to="/"
-          style={{ color: 'var(--ink-light)', fontSize: '0.875rem' }}
-          className="inline-flex items-center gap-2 mb-6 hover:opacity-70 transition-opacity"
-        >
-          <ArrowLeft size={16} />
-          返回
+        <Link to="/" style={{ color: 'var(--ink-light)', fontSize: '0.875rem' }} className="inline-flex items-center gap-2 mb-6 hover:opacity-70 transition-opacity">
+          <ArrowLeft size={16} /> 返回
         </Link>
-
         <div className="flex items-baseline justify-between">
-          <motion.h2
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.2, duration: 0.8 }}
-            style={{ color: 'var(--ink-text)', fontSize: '1.5rem', fontWeight: 400, letterSpacing: '0.02em' }}
-          >
+          <motion.h2 initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2, duration: 0.8 }} style={{ color: 'var(--ink-text)', fontSize: '1.5rem', fontWeight: 400, letterSpacing: '0.02em' }}>
             {location.name}
           </motion.h2>
-          <Link
-            to={`/add?locationId=${id}`}
-            style={{ color: 'var(--ink-faint)', fontSize: '0.8rem', textDecoration: 'none' }}
-            className="hover:opacity-70 transition-opacity"
-          >
+          <Link to={`/add?locationId=${id}`} style={{ color: 'var(--ink-faint)', fontSize: '0.8rem', textDecoration: 'none' }} className="hover:opacity-70 transition-opacity">
             + 添加
           </Link>
         </div>
@@ -81,12 +57,7 @@ export function LocationMemoryScreen() {
       {/* Memory space */}
       <div className="max-w-4xl mx-auto relative" style={{ minHeight: '500px' }}>
         {memories.length === 0 ? (
-          <motion.p
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.4, duration: 0.8 }}
-            style={{ color: 'var(--ink-faint)', fontSize: '0.8rem', textAlign: 'center', marginTop: '80px' }}
-          >
+          <motion.p initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.4, duration: 0.8 }} style={{ color: 'var(--ink-faint)', fontSize: '0.8rem', textAlign: 'center', marginTop: '80px' }}>
             还没有记忆
           </motion.p>
         ) : (
@@ -101,15 +72,33 @@ export function LocationMemoryScreen() {
                 style={{ position: 'absolute', left: `${x}%`, top: `${y}%`, transform: `rotate(${rotation}deg)` }}
               >
                 <Link to={`/memory/${memory.id}`} className="block hover:scale-105 transition-transform">
+                  {/* Photo */}
                   {memory.type === 'photo' && memory.photo && (
-                    <div style={{ width: '160px', boxShadow: '0 2px 8px var(--paper-shadow)', overflow: 'hidden' }}>
-                      <img
-                        src={memory.photo.image_url}
-                        alt={memory.photo.caption ?? ''}
-                        style={{ width: '100%', height: '200px', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)' }}
-                      />
+                    memory.photo.images.length > 1
+                      ? <StackedImages urls={memory.photo.images.map(i => i.image_url)} />
+                      : <div style={{ width: '160px', overflow: 'hidden', boxShadow: '0 2px 8px var(--paper-shadow)' }}>
+                          <img src={memory.photo.images[0]?.image_url} alt="" style={{ width: '100%', height: '200px', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)' }} />
+                        </div>
+                  )}
+
+                  {/* Note: handwritten */}
+                  {memory.type === 'note' && memory.note?.note_type === 'handwritten' && memory.note.images.length > 0 && (
+                    memory.note.images.length > 1
+                      ? <StackedImages urls={memory.note.images.map(i => i.image_url)} />
+                      : <div style={{ width: '160px', overflow: 'hidden', boxShadow: '0 2px 8px var(--paper-shadow)', border: '3px solid var(--paper-warm)' }}>
+                          <img src={memory.note.images[0].image_url} alt="" style={{ width: '100%', height: '200px', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)' }} />
+                        </div>
+                  )}
+
+                  {/* Note: text */}
+                  {memory.type === 'note' && memory.note?.note_type === 'text' && (
+                    <div style={{ width: '160px', minHeight: '120px', padding: '14px', background: 'var(--paper-warm)', boxShadow: '0 2px 8px var(--paper-shadow)', border: '1px solid rgba(58,54,50,0.08)' }}>
+                      <p style={{ color: 'var(--ink-text)', fontSize: '0.78rem', lineHeight: '1.7', margin: 0, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 6, WebkitBoxOrient: 'vertical' }}>
+                        {memory.note.content}
+                      </p>
                     </div>
                   )}
+
                   <div style={{ color: 'var(--ink-faint)', fontSize: '0.7rem', marginTop: '6px', transform: `rotate(-${rotation}deg)` }}>
                     {memory.date}
                   </div>

--- a/src/app/components/MemoryDetailScreen.tsx
+++ b/src/app/components/MemoryDetailScreen.tsx
@@ -1,15 +1,74 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router';
 import { motion } from 'motion/react';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, ChevronLeft, ChevronRight } from 'lucide-react';
 import { getMemoryById } from '../../lib/memoryService';
 import type { Memory } from '../../lib/types';
+
+function ImageGallery({ urls, border }: { urls: string[]; border?: string }) {
+  const [index, setIndex] = useState(0);
+  const [zoomed, setZoomed] = useState(false);
+
+  if (urls.length === 0) return null;
+
+  return (
+    <div>
+      <div style={{ position: 'relative' }}>
+        <div
+          className="overflow-hidden cursor-zoom-in"
+          style={{
+            boxShadow: '0 4px 16px var(--paper-shadow)',
+            border: border ?? 'none',
+            transform: zoomed ? 'scale(1.5)' : 'scale(1)',
+            transition: 'transform 0.4s ease',
+          }}
+          onClick={() => setZoomed(!zoomed)}
+        >
+          <img
+            src={urls[index]}
+            alt=""
+            className="w-full"
+            style={{ display: 'block', filter: 'contrast(0.92) saturate(0.85)' }}
+          />
+        </div>
+
+        {urls.length > 1 && !zoomed && (
+          <>
+            <button
+              onClick={(e) => { e.stopPropagation(); setIndex((i) => (i - 1 + urls.length) % urls.length); }}
+              style={{ position: 'absolute', left: '8px', top: '50%', transform: 'translateY(-50%)', background: 'rgba(58,54,50,0.45)', border: 'none', borderRadius: '50%', width: '32px', height: '32px', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 0 }}
+            >
+              <ChevronLeft size={16} color="white" />
+            </button>
+            <button
+              onClick={(e) => { e.stopPropagation(); setIndex((i) => (i + 1) % urls.length); }}
+              style={{ position: 'absolute', right: '8px', top: '50%', transform: 'translateY(-50%)', background: 'rgba(58,54,50,0.45)', border: 'none', borderRadius: '50%', width: '32px', height: '32px', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 0 }}
+            >
+              <ChevronRight size={16} color="white" />
+            </button>
+          </>
+        )}
+      </div>
+
+      {urls.length > 1 && (
+        <div style={{ display: 'flex', justifyContent: 'center', gap: '6px', marginTop: '10px' }}>
+          {urls.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => setIndex(i)}
+              style={{ width: '6px', height: '6px', borderRadius: '50%', border: 'none', cursor: 'pointer', padding: 0, background: i === index ? 'var(--ink-light)' : 'var(--ink-faint)', opacity: i === index ? 1 : 0.4 }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function MemoryDetailScreen() {
   const { id } = useParams();
   const [memory, setMemory] = useState<Memory | null>(null);
   const [loading, setLoading] = useState(true);
-  const [zoomed, setZoomed] = useState(false);
 
   useEffect(() => {
     getMemoryById(id!).then(setMemory).catch(console.error).finally(() => setLoading(false));
@@ -61,22 +120,29 @@ export function MemoryDetailScreen() {
           transition={{ delay: 0.3, duration: 0.8 }}
           className="max-w-xl w-full"
         >
+          {/* Photo */}
           {memory.type === 'photo' && memory.photo && (
-            <div
-              className="overflow-hidden cursor-zoom-in transition-transform"
-              style={{
-                boxShadow: '0 4px 16px var(--paper-shadow)',
-                transform: zoomed ? 'scale(1.5)' : 'scale(1)',
-                transition: 'transform 0.4s ease',
-              }}
-              onClick={() => setZoomed(!zoomed)}
-            >
-              <img
-                src={memory.photo.image_url}
-                alt={memory.photo.caption ?? ''}
-                className="w-full"
-                style={{ display: 'block', filter: 'contrast(0.92) saturate(0.85)' }}
-              />
+            <ImageGallery urls={memory.photo.images.map((i) => i.image_url)} />
+          )}
+
+          {/* Note: handwritten */}
+          {memory.type === 'note' && memory.note?.note_type === 'handwritten' && memory.note.images.length > 0 && (
+            <div>
+              <ImageGallery urls={memory.note.images.map((i) => i.image_url)} border="4px solid var(--paper-warm)" />
+              {memory.note.content && (
+                <p style={{ color: 'var(--ink-light)', fontSize: '0.85rem', marginTop: '16px', textAlign: 'center', fontStyle: 'italic' }}>
+                  {memory.note.content}
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Note: text */}
+          {memory.type === 'note' && memory.note?.note_type === 'text' && (
+            <div style={{ padding: '40px', background: 'var(--paper-warm)', boxShadow: '0 4px 16px var(--paper-shadow)', border: '1px solid rgba(58,54,50,0.08)' }}>
+              <p style={{ color: 'var(--ink-text)', fontSize: '1rem', lineHeight: '2', margin: 0, whiteSpace: 'pre-wrap' }}>
+                {memory.note.content}
+              </p>
             </div>
           )}
         </motion.div>
@@ -90,9 +156,7 @@ export function MemoryDetailScreen() {
         className="max-w-3xl mx-auto w-full mt-8 text-center"
       >
         {memory.type === 'photo' && memory.photo?.caption && (
-          <p style={{ color: 'var(--ink-text)', fontSize: '0.9rem', marginBottom: '8px' }}>
-            {memory.photo.caption}
-          </p>
+          <p style={{ color: 'var(--ink-text)', fontSize: '0.9rem', marginBottom: '8px' }}>{memory.photo.caption}</p>
         )}
         <div style={{ color: 'var(--ink-faint)', fontSize: '0.8rem' }}>{memory.date}</div>
         {locationName && (

--- a/src/app/components/StackedImages.tsx
+++ b/src/app/components/StackedImages.tsx
@@ -1,0 +1,43 @@
+interface StackedImagesProps {
+  urls: string[]
+  width?: number
+  height?: number
+}
+
+// Shows up to 3 images stacked, back ones peeking to the right
+export function StackedImages({ urls, width = 160, height = 200 }: StackedImagesProps) {
+  const visible = urls.slice(0, 3).reverse() // render back-to-front
+  const offsets = [24, 12, 0]
+  const rotations = [3, 1.5, 0]
+
+  return (
+    <div style={{ position: 'relative', width: width + (visible.length - 1) * 12, height }}>
+      {visible.map((url, i) => {
+        const stackIndex = visible.length - 1 - i
+        return (
+          <div
+            key={url + i}
+            style={{
+              position: 'absolute',
+              left: offsets[stackIndex] ?? 0,
+              top: 0,
+              width,
+              height,
+              zIndex: i + 1,
+              transform: `rotate(${rotations[stackIndex] ?? 0}deg)`,
+              transformOrigin: 'bottom left',
+              overflow: 'hidden',
+              boxShadow: '0 2px 8px var(--paper-shadow)',
+            }}
+          >
+            <img
+              src={url}
+              alt=""
+              style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)' }}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/lib/memoryService.ts
+++ b/src/lib/memoryService.ts
@@ -2,15 +2,21 @@ import { supabase } from './supabaseClient'
 import { uploadImage } from './storageService'
 import type { Memory } from './types'
 
-// Supabase returns one-to-one relations as arrays; unwrap them
 function normalizeMemory(raw: any) {
+  const photo = Array.isArray(raw.photo) ? raw.photo[0] ?? null : raw.photo
+  const note = Array.isArray(raw.note) ? raw.note[0] ?? null : raw.note
   const book = Array.isArray(raw.book) ? raw.book[0] ?? null : raw.book
   const quotes = Array.isArray(raw.quotes) ? raw.quotes : []
+  const photoImages = Array.isArray(raw.photo_images) ? raw.photo_images : []
+  const noteImages = Array.isArray(raw.note_images) ? raw.note_images : []
+
   return {
     ...raw,
-    photo: Array.isArray(raw.photo) ? raw.photo[0] ?? null : raw.photo,
-    note: Array.isArray(raw.note) ? raw.note[0] ?? null : raw.note,
+    photo: photo ? { ...photo, images: photoImages } : null,
+    note: note ? { ...note, images: noteImages } : null,
     book: book ? { ...book, quotes } : null,
+    photo_images: undefined,
+    note_images: undefined,
     quotes: undefined,
   }
 }
@@ -18,7 +24,9 @@ function normalizeMemory(raw: any) {
 const MEMORY_SELECT = `
   *,
   photo:memory_photos(*),
+  photo_images(order, image_url, id),
   note:memory_notes(*),
+  note_images(order, image_url, id),
   book:memory_books(*),
   quotes:book_quotes(*)
 `
@@ -58,12 +66,9 @@ export async function getMemoryById(id: string): Promise<Memory | null> {
 export async function createPhotoMemory(
   locationId: string,
   date: string,
-  imageFile: File,
+  imageFiles: File[],
   caption?: string
 ): Promise<Memory> {
-  const path = `photos/${Date.now()}-${imageFile.name.replace(/\s+/g, '_')}`
-  const imageUrl = await uploadImage(imageFile, path)
-
   const { data: memory, error: memError } = await supabase
     .from('memories')
     .insert({ location_id: locationId, type: 'photo', date })
@@ -74,12 +79,57 @@ export async function createPhotoMemory(
 
   const { error: photoError } = await supabase
     .from('memory_photos')
-    .insert({ memory_id: memory.id, image_url: imageUrl, caption: caption || null })
+    .insert({ memory_id: memory.id, caption: caption || null })
 
   if (photoError) throw photoError
 
-  return {
-    ...memory,
-    photo: { memory_id: memory.id, image_url: imageUrl, caption: caption || null },
-  } as Memory
+  const uploadedImages = await Promise.all(
+    imageFiles.map(async (file, i) => {
+      const path = `photos/${memory.id}-${i}-${file.name.replace(/\s+/g, '_')}`
+      const imageUrl = await uploadImage(file, path)
+      return { memory_id: memory.id, image_url: imageUrl, order: i }
+    })
+  )
+
+  const { error: imgError } = await supabase.from('photo_images').insert(uploadedImages)
+  if (imgError) throw imgError
+
+  return { ...memory, photo: { memory_id: memory.id, caption: caption || null, images: uploadedImages as any } } as Memory
+}
+
+export async function createNoteMemory(
+  locationId: string,
+  date: string,
+  noteType: 'text' | 'handwritten',
+  content?: string,
+  imageFiles?: File[]
+): Promise<Memory> {
+  const { data: memory, error: memError } = await supabase
+    .from('memories')
+    .insert({ location_id: locationId, type: 'note', date })
+    .select()
+    .single()
+
+  if (memError) throw memError
+
+  const { error: noteError } = await supabase
+    .from('memory_notes')
+    .insert({ memory_id: memory.id, note_type: noteType, content: content || null })
+
+  if (noteError) throw noteError
+
+  let uploadedImages: any[] = []
+  if (noteType === 'handwritten' && imageFiles && imageFiles.length > 0) {
+    uploadedImages = await Promise.all(
+      imageFiles.map(async (file, i) => {
+        const path = `notes/${memory.id}-${i}-${file.name.replace(/\s+/g, '_')}`
+        const imageUrl = await uploadImage(file, path)
+        return { memory_id: memory.id, image_url: imageUrl, order: i }
+      })
+    )
+    const { error: imgError } = await supabase.from('note_images').insert(uploadedImages)
+    if (imgError) throw imgError
+  }
+
+  return { ...memory, note: { memory_id: memory.id, note_type: noteType, content: content || null, images: uploadedImages } } as Memory
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,17 +18,31 @@ export interface Memory {
   book?: MemoryBook & { quotes: BookQuote[] }
 }
 
-export interface MemoryPhoto {
+export interface PhotoImage {
+  id: string
   memory_id: string
   image_url: string
+  order: number
+}
+
+export interface NoteImage {
+  id: string
+  memory_id: string
+  image_url: string
+  order: number
+}
+
+export interface MemoryPhoto {
+  memory_id: string
   caption: string | null
+  images: PhotoImage[]
 }
 
 export interface MemoryNote {
   memory_id: string
   note_type: 'handwritten' | 'text'
-  image_url: string | null
   content: string | null
+  images: NoteImage[]
 }
 
 export interface MemoryBook {


### PR DESCRIPTION
## Parent issue

Closes #7

## Summary

- Updated `types.ts`: `MemoryPhoto` and `MemoryNote` now use `images: PhotoImage[]` / `images: NoteImage[]` arrays
- `memoryService`: `normalizeMemory` assembles images arrays; upload functions handle multiple files in parallel
- `AddMemoryScreen`: multi-file upload with grid preview and per-image remove; handwritten note has image upload + optional annotation
- New `StackedImages` component: up to 3 images stacked, back ones peeking 12px right with slight rotation
- `LocationMemoryScreen`: uses `StackedImages` for multi-image memories
- `MemoryDetailScreen`: `ImageGallery` with prev/next arrows and dot indicators; supports zoom

## Test plan

- [ ] Add a photo memory with 3 images — location card shows stacked effect, detail view shows gallery with arrows
- [ ] Add a handwritten note with 2 images + annotation — stacked on location card, gallery + annotation on detail
- [ ] Add a text note — renders as paper card on both views
- [ ] Single-image memories show no navigation controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)