### PR TITLE
feat: book search service (Open Library API)

### DIFF
--- a/src/lib/bookSearchService.test.ts
+++ b/src/lib/bookSearchService.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest'
+import { searchBooks } from './bookSearchService'
+
+describe('searchBooks', () => {
+  it('returns mapped results for a normal response', async () => {
+    const mockResponse = {
+      docs: [
+        {
+          title: 'The Great Gatsby',
+          author_name: ['F. Scott Fitzgerald'],
+          cover_i: 12345,
+          key: '/works/OL45804W',
+        },
+        {
+          title: 'To Kill a Mockingbird',
+          author_name: ['Harper Lee'],
+          cover_i: undefined,
+          key: '/works/OL2798819W',
+        },
+      ],
+    }
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: () => Promise.resolve(mockResponse),
+      })
+    )
+
+    const results = await searchBooks('gatsby')
+
+    expect(results).toHaveLength(2)
+
+    expect(results[0]).toEqual({
+      title: 'The Great Gatsby',
+      author: 'F. Scott Fitzgerald',
+      coverUrl: 'https://covers.openlibrary.org/b/id/12345-M.jpg',
+      olid: 'OL45804W',
+    })
+
+    expect(results[1]).toEqual({
+      title: 'To Kill a Mockingbird',
+      author: 'Harper Lee',
+      coverUrl: null,
+      olid: 'OL2798819W',
+    })
+
+    vi.unstubAllGlobals()
+  })
+
+  it('returns empty array when docs is empty', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({ docs: [] }),
+      })
+    )
+
+    const results = await searchBooks('xyznonexistent')
+
+    expect(results).toEqual([])
+
+    vi.unstubAllGlobals()
+  })
+
+  it('returns empty array for a nonexistent query without throwing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({ docs: [] }),
+      })
+    )
+
+    let results: Awaited<ReturnType<typeof searchBooks>> | undefined
+    let error: unknown
+
+    try {
+      results = await searchBooks('zzzzzzzzzzzzzzzzzzzzzzz')
+    } catch (e) {
+      error = e
+    }
+
+    expect(error).toBeUndefined()
+    expect(results).toEqual([])
+
+    vi.unstubAllGlobals()
+  })
+
+  it('returns empty array when fetch throws', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('Network error'))
+    )
+
+    const results = await searchBooks('anything')
+
+    expect(results).toEqual([])
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/lib/bookSearchService.ts
+++ b/src/lib/bookSearchService.ts
@@ -1,0 +1,46 @@
+export interface BookSearchResult {
+  title: string
+  author: string
+  coverUrl: string | null
+  olid: string // Open Library work ID, e.g. "OL45804W"
+}
+
+interface OpenLibraryDoc {
+  title?: string
+  author_name?: string[]
+  cover_i?: number
+  key?: string
+}
+
+interface OpenLibraryResponse {
+  docs?: OpenLibraryDoc[]
+}
+
+export async function searchBooks(query: string): Promise<BookSearchResult[]> {
+  try {
+    const url = `https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&limit=10&fields=title,author_name,cover_i,key`
+    const response = await fetch(url)
+    const data: OpenLibraryResponse = await response.json()
+
+    if (!data.docs || data.docs.length === 0) {
+      return []
+    }
+
+    return data.docs.map((doc) => {
+      const coverUrl = doc.cover_i
+        ? `https://covers.openlibrary.org/b/id/${doc.cover_i}-M.jpg`
+        : null
+
+      const olid = doc.key ? doc.key.replace('/works/', '') : ''
+
+      return {
+        title: doc.title ?? '',
+        author: doc.author_name?.[0] ?? '',
+        coverUrl,
+        olid,
+      }
+    })
+  } catch {
+    return []
+  }
+}


### PR DESCRIPTION
## Parent issue

Closes #8

## Summary

- New `src/lib/bookSearchService.ts`: `searchBooks(query)` calls Open Library Search API, returns `BookSearchResult[]` with `title`, `author`, `coverUrl`, `olid`
- Cover URL built from `cover_i` field: `https://covers.openlibrary.org/b/id/{id}-M.jpg`
- Returns `[]` on empty results or any fetch error — never throws
- 4 Vitest tests: normal response parsing, empty results, nonexistent query, fetch error (all pass)

## Test plan

- [ ] All 9 tests pass (`npm run test -- --run`)
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)