### PR TITLE
feat: timeline view end-to-end

### DIFF
--- a/src/app/components/MapScreen.tsx
+++ b/src/app/components/MapScreen.tsx
@@ -110,6 +110,46 @@ export function MapScreen() {
         </p>
       </motion.div>
 
+      {/* Nav tabs */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.35, duration: 0.6 }}
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          gap: '32px',
+          paddingBottom: '16px',
+          borderBottom: '1px solid var(--ink-faint)',
+          marginBottom: '8px',
+        }}
+      >
+        <span
+          style={{
+            color: 'var(--ink-text)',
+            fontSize: '0.875rem',
+            paddingBottom: '4px',
+            borderBottom: '1px solid var(--ink-text)',
+            fontFamily: 'var(--font-serif)',
+          }}
+        >
+          地图
+        </span>
+        <Link
+          to="/timeline"
+          style={{
+            color: 'var(--ink-faint)',
+            fontSize: '0.875rem',
+            textDecoration: 'none',
+            paddingBottom: '4px',
+            fontFamily: 'var(--font-serif)',
+          }}
+          className="hover:opacity-70 transition-opacity"
+        >
+          时间线
+        </Link>
+      </motion.div>
+
       {/* Search */}
       <motion.div
         initial={{ opacity: 0 }}

--- a/src/app/components/TimelineScreen.tsx
+++ b/src/app/components/TimelineScreen.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { motion } from 'motion/react';
+import { getAllMemories } from '../../lib/memoryService';
+import type { Memory } from '../../lib/types';
+
+function MemoryThumbnail({ memory }: { memory: Memory }) {
+  const thumbStyle: React.CSSProperties = {
+    width: 60,
+    height: 60,
+    objectFit: 'cover',
+    flexShrink: 0,
+    border: '1px solid var(--ink-faint)',
+    display: 'block',
+  };
+
+  if (memory.type === 'photo' && memory.photo?.image_url) {
+    return (
+      <img
+        src={memory.photo.image_url}
+        alt={memory.photo.caption ?? '照片'}
+        style={thumbStyle}
+      />
+    );
+  }
+
+  if (memory.type === 'note') {
+    if (memory.note?.note_type === 'handwritten' && memory.note?.image_url) {
+      return (
+        <img
+          src={memory.note.image_url}
+          alt="手写笔记"
+          style={thumbStyle}
+        />
+      );
+    }
+    // text note — show excerpt in a box
+    const excerpt = memory.note?.content
+      ? memory.note.content.slice(0, 40)
+      : '';
+    return (
+      <div
+        style={{
+          ...thumbStyle,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'var(--paper-warm)',
+          padding: '4px',
+          fontSize: '0.65rem',
+          color: 'var(--ink-light)',
+          fontFamily: 'var(--font-serif)',
+          overflow: 'hidden',
+          lineHeight: 1.4,
+          wordBreak: 'break-all',
+        }}
+      >
+        {excerpt || '…'}
+      </div>
+    );
+  }
+
+  if (memory.type === 'book') {
+    if (memory.book?.cover_url) {
+      return (
+        <img
+          src={memory.book.cover_url}
+          alt={memory.book.title}
+          style={thumbStyle}
+        />
+      );
+    }
+    return (
+      <div
+        style={{
+          ...thumbStyle,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'var(--paper-warm)',
+          padding: '6px',
+          fontSize: '0.65rem',
+          color: 'var(--ink-light)',
+          fontFamily: 'var(--font-serif)',
+          textAlign: 'center',
+          wordBreak: 'break-all',
+        }}
+      >
+        {memory.book?.title ?? '书'}
+      </div>
+    );
+  }
+
+  // fallback placeholder
+  return (
+    <div
+      style={{
+        ...thumbStyle,
+        background: 'var(--paper-warm)',
+      }}
+    />
+  );
+}
+
+function typeLabel(memory: Memory): string {
+  if (memory.type === 'photo') return '照片';
+  if (memory.type === 'book') return '读书';
+  if (memory.type === 'note') {
+    return memory.note?.note_type === 'handwritten' ? '手写' : '文字';
+  }
+  return '';
+}
+
+export function TimelineScreen() {
+  const [memories, setMemories] = useState<Memory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    getAllMemories()
+      .then(setMemories)
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.8 }}
+      className="min-h-screen flex flex-col"
+      style={{ fontFamily: 'var(--font-serif)' }}
+    >
+      {/* Header */}
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.3, duration: 0.8 }}
+        className="text-center py-8 px-6"
+      >
+        <h1
+          className="mb-2"
+          style={{
+            color: 'var(--ink-text)',
+            fontSize: '1.75rem',
+            fontWeight: 400,
+            letterSpacing: '0.02em',
+          }}
+        >
+          时间线
+        </h1>
+        <p style={{ color: 'var(--ink-light)', fontSize: '0.875rem', fontWeight: 400 }}>
+          所有记忆，按时间排列
+        </p>
+      </motion.div>
+
+      {/* Nav tabs */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.4, duration: 0.6 }}
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          gap: '32px',
+          paddingBottom: '16px',
+          borderBottom: '1px solid var(--ink-faint)',
+          marginBottom: '8px',
+        }}
+      >
+        <Link
+          to="/"
+          style={{
+            color: 'var(--ink-faint)',
+            fontSize: '0.875rem',
+            textDecoration: 'none',
+            paddingBottom: '4px',
+          }}
+          className="hover:opacity-70 transition-opacity"
+        >
+          地图
+        </Link>
+        <span
+          style={{
+            color: 'var(--ink-text)',
+            fontSize: '0.875rem',
+            paddingBottom: '4px',
+            borderBottom: '1px solid var(--ink-text)',
+          }}
+        >
+          时间线
+        </span>
+      </motion.div>
+
+      {/* Content */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.5, duration: 0.8 }}
+        className="flex-1 px-6 pb-8"
+        style={{ maxWidth: '720px', margin: '0 auto', width: '100%' }}
+      >
+        {loading ? (
+          <div
+            style={{
+              textAlign: 'center',
+              paddingTop: '80px',
+              color: 'var(--ink-faint)',
+              fontSize: '0.875rem',
+            }}
+          >
+            …
+          </div>
+        ) : memories.length === 0 ? (
+          <div
+            style={{
+              textAlign: 'center',
+              paddingTop: '80px',
+              color: 'var(--ink-faint)',
+              fontSize: '0.875rem',
+            }}
+          >
+            还没有记忆
+          </div>
+        ) : (
+          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+            {memories.map((memory, i) => {
+              const locationName = (memory as any).location?.name ?? '';
+              return (
+                <motion.li
+                  key={memory.id}
+                  initial={{ opacity: 0, y: 6 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.55 + i * 0.04, duration: 0.5 }}
+                >
+                  <button
+                    onClick={() => navigate(`/memory/${memory.id}`)}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '16px',
+                      width: '100%',
+                      background: 'transparent',
+                      border: 'none',
+                      borderBottom: '1px solid var(--ink-faint)',
+                      padding: '16px 0',
+                      cursor: 'pointer',
+                      textAlign: 'left',
+                    }}
+                    className="hover:opacity-70 transition-opacity"
+                  >
+                    {/* Thumbnail */}
+                    <MemoryThumbnail memory={memory} />
+
+                    {/* Meta */}
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div
+                        style={{
+                          color: 'var(--ink-text)',
+                          fontSize: '0.875rem',
+                          marginBottom: '4px',
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                        }}
+                      >
+                        {locationName || '未知地点'}
+                      </div>
+                      <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
+                        <span
+                          style={{
+                            color: 'var(--ink-faint)',
+                            fontSize: '0.75rem',
+                          }}
+                        >
+                          {memory.date}
+                        </span>
+                        <span
+                          style={{
+                            color: 'var(--ink-light)',
+                            fontSize: '0.72rem',
+                            padding: '1px 6px',
+                            border: '1px solid var(--ink-faint)',
+                          }}
+                        >
+                          {typeLabel(memory)}
+                        </span>
+                      </div>
+                    </div>
+                  </button>
+                </motion.li>
+              );
+            })}
+          </ul>
+        )}
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -3,6 +3,7 @@ import { MapScreen } from './components/MapScreen';
 import { LocationMemoryScreen } from './components/LocationMemoryScreen';
 import { MemoryDetailScreen } from './components/MemoryDetailScreen';
 import { AddMemoryScreen } from './components/AddMemoryScreen';
+import { TimelineScreen } from './components/TimelineScreen';
 
 const Root = () => {
   return <MapScreen />;
@@ -20,10 +21,18 @@ const AddRoot = () => {
   return <AddMemoryScreen />;
 };
 
+const TimelineRoot = () => {
+  return <TimelineScreen />;
+};
+
 export const router = createBrowserRouter([
   {
     path: '/',
     Component: Root,
+  },
+  {
+    path: '/timeline',
+    Component: TimelineRoot,
   },
   {
     path: '/location/:id',


### PR DESCRIPTION
## Parent issue

Closes #10

## Summary

- New `TimelineScreen`: reverse-chronological feed, 60×60 thumbnails, location name + date + type badge, staggered fade-in animation
- Added `/timeline` route in `src/app/routes.tsx`
- `MapScreen`: tab bar (地图 / 时间线) to switch between views

## Test plan

- [ ] Timeline shows all memories in reverse date order
- [ ] Photo/handwritten note memories show image thumbnail
- [ ] Text note shows first ~40 chars as text excerpt
- [ ] Clicking a row navigates to detail page
- [ ] Tab switching between 地图 and 时间线 works
- [ ] Empty state shows "还没有记忆"

🤖 Generated with [Claude Code](https://claude.com/claude-code)