### PR TITLE
fix: tab nav no remount on switch, remove divider line

### DIFF
--- a/src/app/components/AppLayout.tsx
+++ b/src/app/components/AppLayout.tsx
@@ -1,0 +1,52 @@
+import { Outlet, NavLink } from 'react-router';
+import { motion } from 'motion/react';
+
+export function AppLayout() {
+  return (
+    <div className="min-h-screen flex flex-col" style={{ fontFamily: 'var(--font-serif)' }}>
+      {/* Title */}
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.3, duration: 0.8 }}
+        className="text-center py-8 px-6"
+      >
+        <h1 className="mb-2" style={{ color: 'var(--ink-text)', fontSize: '1.75rem', fontWeight: 400, letterSpacing: '0.02em' }}>
+          朝花夕拾
+        </h1>
+        <p style={{ color: 'var(--ink-light)', fontSize: '0.875rem', fontWeight: 400 }}>
+          Dawn Blossoms Plucked at Dusk
+        </p>
+      </motion.div>
+
+      {/* Tab nav */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.35, duration: 0.6 }}
+        style={{ display: 'flex', justifyContent: 'center', gap: '32px', marginBottom: '8px' }}
+      >
+        {[{ to: '/', label: '地图', end: true }, { to: '/timeline', label: '时间线', end: false }].map(({ to, label, end }) => (
+          <NavLink
+            key={to}
+            to={to}
+            end={end}
+            style={({ isActive }) => ({
+              color: isActive ? 'var(--ink-text)' : 'var(--ink-faint)',
+              fontSize: '0.875rem',
+              textDecoration: 'none',
+              paddingBottom: '4px',
+              borderBottom: isActive ? '1px solid var(--ink-text)' : 'none',
+              fontFamily: 'var(--font-serif)',
+            })}
+          >
+            {label}
+          </NavLink>
+        ))}
+      </motion.div>
+
+      {/* Page content */}
+      <Outlet />
+    </div>
+  );
+}

--- a/src/app/components/MapScreen.tsx
+++ b/src/app/components/MapScreen.tsx
@@ -88,68 +88,7 @@ export function MapScreen() {
   }
 
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: 0.8 }}
-      className="min-h-screen flex flex-col"
-      style={{ fontFamily: 'var(--font-serif)' }}
-    >
-      {/* Title */}
-      <motion.div
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.3, duration: 0.8 }}
-        className="text-center py-8 px-6"
-      >
-        <h1 className="mb-2" style={{ color: 'var(--ink-text)', fontSize: '1.75rem', fontWeight: 400, letterSpacing: '0.02em' }}>
-          朝花夕拾
-        </h1>
-        <p style={{ color: 'var(--ink-light)', fontSize: '0.875rem', fontWeight: 400 }}>
-          Dawn Blossoms Plucked at Dusk
-        </p>
-      </motion.div>
-
-      {/* Nav tabs */}
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ delay: 0.35, duration: 0.6 }}
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          gap: '32px',
-          paddingBottom: '16px',
-          borderBottom: '1px solid var(--ink-faint)',
-          marginBottom: '8px',
-        }}
-      >
-        <span
-          style={{
-            color: 'var(--ink-text)',
-            fontSize: '0.875rem',
-            paddingBottom: '4px',
-            borderBottom: '1px solid var(--ink-text)',
-            fontFamily: 'var(--font-serif)',
-          }}
-        >
-          地图
-        </span>
-        <Link
-          to="/timeline"
-          style={{
-            color: 'var(--ink-faint)',
-            fontSize: '0.875rem',
-            textDecoration: 'none',
-            paddingBottom: '4px',
-            fontFamily: 'var(--font-serif)',
-          }}
-          className="hover:opacity-70 transition-opacity"
-        >
-          时间线
-        </Link>
-      </motion.div>
-
+    <div className="flex flex-col flex-1" style={{ fontFamily: 'var(--font-serif)' }}>
       {/* Search */}
       <motion.div
         initial={{ opacity: 0 }}
@@ -329,6 +268,6 @@ export function MapScreen() {
           </motion.div>
         )}
       </AnimatePresence>
-    </motion.div>
+    </div>
   );
 }

--- a/src/app/components/TimelineScreen.tsx
+++ b/src/app/components/TimelineScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link, useNavigate } from 'react-router';
+import { useNavigate } from 'react-router';
 import { motion } from 'motion/react';
 import { getAllMemories } from '../../lib/memoryService';
 import type { Memory } from '../../lib/types';
@@ -14,10 +14,10 @@ function MemoryThumbnail({ memory }: { memory: Memory }) {
     display: 'block',
   };
 
-  if (memory.type === 'photo' && memory.photo?.image_url) {
+  if (memory.type === 'photo' && memory.photo?.images[0]) {
     return (
       <img
-        src={memory.photo.image_url}
+        src={memory.photo.images[0].image_url}
         alt={memory.photo.caption ?? '照片'}
         style={thumbStyle}
       />
@@ -25,10 +25,10 @@ function MemoryThumbnail({ memory }: { memory: Memory }) {
   }
 
   if (memory.type === 'note') {
-    if (memory.note?.note_type === 'handwritten' && memory.note?.image_url) {
+    if (memory.note?.note_type === 'handwritten' && memory.note.images[0]) {
       return (
         <img
-          src={memory.note.image_url}
+          src={memory.note.images[0].image_url}
           alt="手写笔记"
           style={thumbStyle}
         />
@@ -127,79 +127,10 @@ export function TimelineScreen() {
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      transition={{ duration: 0.8 }}
-      className="min-h-screen flex flex-col"
-      style={{ fontFamily: 'var(--font-serif)' }}
+      transition={{ delay: 0.1, duration: 0.6 }}
+      className="flex-1 px-6 pb-8"
+      style={{ maxWidth: '720px', margin: '0 auto', width: '100%', fontFamily: 'var(--font-serif)' }}
     >
-      {/* Header */}
-      <motion.div
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.3, duration: 0.8 }}
-        className="text-center py-8 px-6"
-      >
-        <h1
-          className="mb-2"
-          style={{
-            color: 'var(--ink-text)',
-            fontSize: '1.75rem',
-            fontWeight: 400,
-            letterSpacing: '0.02em',
-          }}
-        >
-          时间线
-        </h1>
-        <p style={{ color: 'var(--ink-light)', fontSize: '0.875rem', fontWeight: 400 }}>
-          所有记忆，按时间排列
-        </p>
-      </motion.div>
-
-      {/* Nav tabs */}
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ delay: 0.4, duration: 0.6 }}
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          gap: '32px',
-          paddingBottom: '16px',
-          borderBottom: '1px solid var(--ink-faint)',
-          marginBottom: '8px',
-        }}
-      >
-        <Link
-          to="/"
-          style={{
-            color: 'var(--ink-faint)',
-            fontSize: '0.875rem',
-            textDecoration: 'none',
-            paddingBottom: '4px',
-          }}
-          className="hover:opacity-70 transition-opacity"
-        >
-          地图
-        </Link>
-        <span
-          style={{
-            color: 'var(--ink-text)',
-            fontSize: '0.875rem',
-            paddingBottom: '4px',
-            borderBottom: '1px solid var(--ink-text)',
-          }}
-        >
-          时间线
-        </span>
-      </motion.div>
-
-      {/* Content */}
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ delay: 0.5, duration: 0.8 }}
-        className="flex-1 px-6 pb-8"
-        style={{ maxWidth: '720px', margin: '0 auto', width: '100%' }}
-      >
         {loading ? (
           <div
             style={{
@@ -293,7 +224,6 @@ export function TimelineScreen() {
             })}
           </ul>
         )}
-      </motion.div>
     </motion.div>
   );
 }

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,49 +1,30 @@
 import { createBrowserRouter } from 'react-router';
+import { AppLayout } from './components/AppLayout';
 import { MapScreen } from './components/MapScreen';
 import { LocationMemoryScreen } from './components/LocationMemoryScreen';
 import { MemoryDetailScreen } from './components/MemoryDetailScreen';
 import { AddMemoryScreen } from './components/AddMemoryScreen';
 import { TimelineScreen } from './components/TimelineScreen';
 
-const Root = () => {
-  return <MapScreen />;
-};
-
-const LocationRoot = () => {
-  return <LocationMemoryScreen />;
-};
-
-const MemoryRoot = () => {
-  return <MemoryDetailScreen />;
-};
-
-const AddRoot = () => {
-  return <AddMemoryScreen />;
-};
-
-const TimelineRoot = () => {
-  return <TimelineScreen />;
-};
-
 export const router = createBrowserRouter([
   {
     path: '/',
-    Component: Root,
-  },
-  {
-    path: '/timeline',
-    Component: TimelineRoot,
+    Component: AppLayout,
+    children: [
+      { index: true, Component: MapScreen },
+      { path: 'timeline', Component: TimelineScreen },
+    ],
   },
   {
     path: '/location/:id',
-    Component: LocationRoot,
+    Component: LocationMemoryScreen,
   },
   {
     path: '/memory/:id',
-    Component: MemoryRoot,
+    Component: MemoryDetailScreen,
   },
   {
     path: '/add',
-    Component: AddRoot,
+    Component: AddMemoryScreen,
   },
 ]);


### PR DESCRIPTION
## Summary

- New `AppLayout` component holds the title + tab nav, renders `<Outlet />` for child routes
- Routes restructured: `/` and `/timeline` are now nested children of `AppLayout` — switching tabs no longer remounts the header
- `NavLink` handles active state automatically, no manual active checks needed
- Removed `borderBottom` divider line from tab nav
- Fixed `MemoryThumbnail` in `TimelineScreen`: was reading stale `image_url` field, now correctly reads `images[0].image_url`

## Test plan

- [ ] Switching 地图 ↔ 时间线 keeps the title/tabs stable (no flicker)
- [ ] Active tab is underlined, inactive tab is faint
- [ ] No divider line between tabs and content
- [ ] Photo/note thumbnails show correctly in timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)