### PR TITLE
feat: book memory end-to-end

### DIFF
--- a/src/app/components/AddMemoryScreen.tsx
+++ b/src/app/components/AddMemoryScreen.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
-import { motion } from 'motion/react';
-import { ArrowLeft, X } from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
+import { ArrowLeft, X, Plus, Minus } from 'lucide-react';
 import { getLocations } from '../../lib/locationService';
-import { createPhotoMemory, createNoteMemory } from '../../lib/memoryService';
+import { createPhotoMemory, createNoteMemory, createBookMemory } from '../../lib/memoryService';
+import { searchBooks } from '../../lib/bookSearchService';
+import type { BookSearchResult } from '../../lib/bookSearchService';
 import type { Location } from '../../lib/types';
 
 type MemoryType = 'photo' | 'note' | 'book';
@@ -30,13 +32,30 @@ export function AddMemoryScreen() {
   const [locations, setLocations] = useState<Location[]>([]);
   const [locationId, setLocationId] = useState(preselectedLocationId);
   const [date, setDate] = useState(new Date().toISOString().slice(0, 10));
+
+  // photo / note
   const [imageFiles, setImageFiles] = useState<File[]>([]);
   const [imagePreviews, setImagePreviews] = useState<string[]>([]);
   const [caption, setCaption] = useState('');
   const [noteContent, setNoteContent] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // book
+  const [bookQuery, setBookQuery] = useState('');
+  const [bookResults, setBookResults] = useState<BookSearchResult[]>([]);
+  const [bookSearching, setBookSearching] = useState(false);
+  const [bookTitle, setBookTitle] = useState('');
+  const [bookAuthor, setBookAuthor] = useState('');
+  const [bookCoverUrl, setBookCoverUrl] = useState<string | null>(null);
+  const [bookCoverFile, setBookCoverFile] = useState<File | null>(null);
+  const [bookCoverPreview, setBookCoverPreview] = useState<string | null>(null);
+  const [readingNotes, setReadingNotes] = useState('');
+  const [quotes, setQuotes] = useState<string[]>(['']);
+  const bookDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const coverInputRef = useRef<HTMLInputElement>(null);
+
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     getLocations().then(setLocations).catch(console.error);
@@ -47,6 +66,15 @@ export function AddMemoryScreen() {
     setImagePreviews([]);
     setCaption('');
     setNoteContent('');
+    setBookQuery('');
+    setBookResults([]);
+    setBookTitle('');
+    setBookAuthor('');
+    setBookCoverUrl(null);
+    setBookCoverFile(null);
+    setBookCoverPreview(null);
+    setReadingNotes('');
+    setQuotes(['']);
     setError('');
   }, [type, noteSubtype]);
 
@@ -63,6 +91,49 @@ export function AddMemoryScreen() {
     setImagePreviews((prev) => prev.filter((_, i) => i !== index));
   }
 
+  function handleBookQueryChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const q = e.target.value;
+    setBookQuery(q);
+    if (bookDebounceRef.current) clearTimeout(bookDebounceRef.current);
+    if (!q.trim()) { setBookResults([]); return; }
+    bookDebounceRef.current = setTimeout(async () => {
+      setBookSearching(true);
+      setBookResults(await searchBooks(q));
+      setBookSearching(false);
+    }, 400);
+  }
+
+  function selectBookResult(result: BookSearchResult) {
+    setBookTitle(result.title);
+    setBookAuthor(result.author);
+    setBookCoverUrl(result.coverUrl);
+    setBookCoverFile(null);
+    setBookCoverPreview(result.coverUrl);
+    setBookQuery('');
+    setBookResults([]);
+  }
+
+  function handleCoverFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setBookCoverFile(file);
+    setBookCoverUrl(null);
+    setBookCoverPreview(URL.createObjectURL(file));
+    e.target.value = '';
+  }
+
+  function updateQuote(index: number, value: string) {
+    setQuotes((prev) => prev.map((q, i) => i === index ? value : q));
+  }
+
+  function addQuote() {
+    setQuotes((prev) => [...prev, '']);
+  }
+
+  function removeQuote(index: number) {
+    setQuotes((prev) => prev.filter((_, i) => i !== index));
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!locationId) { setError('请选择地点'); return; }
@@ -70,6 +141,7 @@ export function AddMemoryScreen() {
     if (type === 'photo' && imageFiles.length === 0) { setError('请至少上传一张照片'); return; }
     if (type === 'note' && noteSubtype === 'handwritten' && imageFiles.length === 0) { setError('请至少上传一张手写笔记图片'); return; }
     if (type === 'note' && noteSubtype === 'text' && !noteContent.trim()) { setError('请输入笔记内容'); return; }
+    if (type === 'book' && !bookTitle.trim()) { setError('请输入书名'); return; }
 
     setSaving(true);
     setError('');
@@ -78,6 +150,15 @@ export function AddMemoryScreen() {
         await createPhotoMemory(locationId, date, imageFiles, caption || undefined);
       } else if (type === 'note') {
         await createNoteMemory(locationId, date, noteSubtype, noteContent || undefined, imageFiles.length > 0 ? imageFiles : undefined);
+      } else if (type === 'book') {
+        const filledQuotes = quotes.map((q) => q.trim()).filter(Boolean);
+        await createBookMemory(locationId, date, {
+          title: bookTitle.trim(),
+          author: bookAuthor.trim(),
+          coverUrl: bookCoverUrl,
+          coverFile: bookCoverFile ?? undefined,
+          readingNotes: readingNotes.trim() || undefined,
+        }, filledQuotes);
       }
       navigate(`/location/${locationId}`);
     } catch (err: any) {
@@ -105,8 +186,8 @@ export function AddMemoryScreen() {
 
         {/* Type tabs */}
         <div className="flex gap-6 mb-8">
-          {([{ key: 'photo', label: '照片', enabled: true }, { key: 'note', label: '笔记', enabled: true }, { key: 'book', label: '书籍', enabled: false }] as const).map(({ key, label, enabled }) => (
-            <button key={key} onClick={() => enabled && setType(key as MemoryType)} disabled={!enabled} style={{ background: 'none', border: 'none', cursor: enabled ? 'pointer' : 'default', fontFamily: 'var(--font-serif)', fontSize: '0.875rem', color: !enabled ? 'var(--ink-faint)' : type === key ? 'var(--ink-text)' : 'var(--ink-light)', paddingBottom: '4px', borderBottom: type === key && enabled ? '1px solid var(--ink-text)' : 'none', transition: 'all 0.2s' }}>
+          {([{ key: 'photo', label: '照片' }, { key: 'note', label: '笔记' }, { key: 'book', label: '书籍' }] as const).map(({ key, label }) => (
+            <button key={key} onClick={() => setType(key)} style={{ background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'var(--font-serif)', fontSize: '0.875rem', color: type === key ? 'var(--ink-text)' : 'var(--ink-light)', paddingBottom: '4px', borderBottom: type === key ? '1px solid var(--ink-text)' : 'none', transition: 'all 0.2s' }}>
               {label}
             </button>
           ))}
@@ -124,12 +205,10 @@ export function AddMemoryScreen() {
         )}
 
         <form onSubmit={handleSubmit} className="space-y-8">
-          {/* Image upload area */}
+          {/* Image upload (photo / handwritten note) */}
           {showImageUpload && (
             <div>
               <input ref={fileInputRef} type="file" accept="image/*" multiple onChange={handleFileChange} className="hidden" />
-
-              {/* Previews grid */}
               {imagePreviews.length > 0 && (
                 <div className="grid grid-cols-3 gap-2 mb-3">
                   {imagePreviews.map((src, i) => (
@@ -142,8 +221,6 @@ export function AddMemoryScreen() {
                   ))}
                 </div>
               )}
-
-              {/* Add more / first upload button */}
               <div className="flex items-center justify-center cursor-pointer transition-opacity hover:opacity-70" style={{ height: imagePreviews.length > 0 ? '48px' : '180px', border: '1px dashed var(--ink-faint)', background: 'var(--paper-warm)' }} onClick={() => fileInputRef.current?.click()}>
                 <span style={{ color: 'var(--ink-faint)', fontSize: '0.8rem' }}>
                   {imagePreviews.length > 0 ? '+ 继续添加' : type === 'photo' ? '点击上传照片（可多选）' : '上传手写笔记照片（可多选）'}
@@ -174,6 +251,114 @@ export function AddMemoryScreen() {
               <label style={labelStyle}>标注（可选）</label>
               <input type="text" value={noteContent} onChange={(e) => setNoteContent(e.target.value)} placeholder="补充一点文字…" style={inputStyle} />
             </div>
+          )}
+
+          {/* Book fields */}
+          {type === 'book' && (
+            <>
+              {/* Search */}
+              <div style={{ position: 'relative' }}>
+                <label style={labelStyle}>搜索书名</label>
+                <input
+                  type="text"
+                  value={bookQuery}
+                  onChange={handleBookQueryChange}
+                  placeholder="输入书名搜索…"
+                  style={inputStyle}
+                />
+                {bookSearching && (
+                  <span style={{ position: 'absolute', right: 0, bottom: '12px', color: 'var(--ink-faint)', fontSize: '0.75rem' }}>搜索中…</span>
+                )}
+                <AnimatePresence>
+                  {bookResults.length > 0 && (
+                    <motion.div
+                      initial={{ opacity: 0, y: -4 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -4 }}
+                      style={{ position: 'absolute', top: '100%', left: 0, right: 0, background: 'var(--paper-bg)', border: '1px solid var(--ink-faint)', boxShadow: '0 4px 12px var(--paper-shadow)', zIndex: 100, maxHeight: '240px', overflowY: 'auto' }}
+                    >
+                      {bookResults.map((r, i) => (
+                        <button
+                          key={r.id + i}
+                          type="button"
+                          onClick={() => selectBookResult(r)}
+                          style={{ display: 'flex', alignItems: 'center', gap: '10px', width: '100%', padding: '10px 12px', background: 'transparent', border: 'none', borderBottom: i < bookResults.length - 1 ? '1px solid var(--ink-faint)' : 'none', cursor: 'pointer', textAlign: 'left', fontFamily: 'var(--font-serif)' }}
+                          className="hover:opacity-60 transition-opacity"
+                        >
+                          {r.coverUrl && <img src={r.coverUrl} alt="" style={{ width: '32px', height: '44px', objectFit: 'cover', flexShrink: 0 }} />}
+                          <div>
+                            <div style={{ color: 'var(--ink-text)', fontSize: '0.85rem' }}>{r.title}</div>
+                            <div style={{ color: 'var(--ink-light)', fontSize: '0.75rem', marginTop: '2px' }}>{r.author}</div>
+                          </div>
+                        </button>
+                      ))}
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+
+              {/* Title */}
+              <div>
+                <label style={labelStyle}>书名</label>
+                <input type="text" value={bookTitle} onChange={(e) => setBookTitle(e.target.value)} placeholder="书名" style={inputStyle} />
+              </div>
+
+              {/* Author */}
+              <div>
+                <label style={labelStyle}>作者</label>
+                <input type="text" value={bookAuthor} onChange={(e) => setBookAuthor(e.target.value)} placeholder="作者" style={inputStyle} />
+              </div>
+
+              {/* Cover */}
+              <div>
+                <label style={labelStyle}>封面（可选）</label>
+                <input ref={coverInputRef} type="file" accept="image/*" onChange={handleCoverFileChange} className="hidden" />
+                {bookCoverPreview ? (
+                  <div style={{ display: 'flex', alignItems: 'flex-end', gap: '12px' }}>
+                    <img src={bookCoverPreview} alt="" style={{ width: '80px', height: '110px', objectFit: 'cover', boxShadow: '0 2px 8px var(--paper-shadow)' }} />
+                    <button type="button" onClick={() => { setBookCoverFile(null); setBookCoverUrl(null); setBookCoverPreview(null); }} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--ink-faint)', fontSize: '0.75rem', fontFamily: 'var(--font-serif)', paddingBottom: '4px' }}>
+                      移除
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex items-center justify-center cursor-pointer hover:opacity-70 transition-opacity" style={{ width: '80px', height: '110px', border: '1px dashed var(--ink-faint)', background: 'var(--paper-warm)' }} onClick={() => coverInputRef.current?.click()}>
+                    <span style={{ color: 'var(--ink-faint)', fontSize: '0.7rem', textAlign: 'center', padding: '4px' }}>上传封面</span>
+                  </div>
+                )}
+              </div>
+
+              {/* Reading notes */}
+              <div>
+                <label style={labelStyle}>读书笔记（可选）</label>
+                <textarea value={readingNotes} onChange={(e) => setReadingNotes(e.target.value)} placeholder="写下你的感想…" rows={5} style={{ ...inputStyle, borderBottom: 'none', border: '1px solid var(--ink-faint)', padding: '12px', resize: 'vertical', lineHeight: '1.8' }} />
+              </div>
+
+              {/* Quotes */}
+              <div>
+                <label style={labelStyle}>摘录（可选）</label>
+                <div className="space-y-3">
+                  {quotes.map((q, i) => (
+                    <div key={i} style={{ display: 'flex', gap: '8px', alignItems: 'flex-start' }}>
+                      <textarea
+                        value={q}
+                        onChange={(e) => updateQuote(i, e.target.value)}
+                        placeholder={`摘录 ${i + 1}…`}
+                        rows={2}
+                        style={{ ...inputStyle, borderBottom: 'none', border: '1px solid var(--ink-faint)', padding: '8px 10px', resize: 'vertical', lineHeight: '1.7', fontSize: '0.85rem', flex: 1 }}
+                      />
+                      {quotes.length > 1 && (
+                        <button type="button" onClick={() => removeQuote(i)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--ink-faint)', padding: '8px 0', flexShrink: 0 }}>
+                          <Minus size={14} />
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                  <button type="button" onClick={addQuote} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--ink-light)', fontSize: '0.8rem', fontFamily: 'var(--font-serif)', display: 'flex', alignItems: 'center', gap: '4px', padding: 0 }}>
+                    <Plus size={12} /> 添加摘录
+                  </button>
+                </div>
+              </div>
+            </>
           )}
 
           {/* Location */}

--- a/src/app/components/LocationMemoryScreen.tsx
+++ b/src/app/components/LocationMemoryScreen.tsx
@@ -99,6 +99,18 @@ export function LocationMemoryScreen() {
                     </div>
                   )}
 
+                  {/* Book */}
+                  {memory.type === 'book' && memory.book && (
+                    memory.book.cover_url
+                      ? <div style={{ width: '110px', overflow: 'hidden', boxShadow: '0 2px 8px var(--paper-shadow)' }}>
+                          <img src={memory.book.cover_url} alt="" style={{ width: '100%', height: '150px', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)' }} />
+                        </div>
+                      : <div style={{ width: '110px', height: '150px', padding: '12px', background: 'var(--paper-warm)', boxShadow: '0 2px 8px var(--paper-shadow)', border: '1px solid rgba(58,54,50,0.08)', display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+                          <p style={{ color: 'var(--ink-text)', fontSize: '0.78rem', lineHeight: '1.5', margin: 0 }}>{memory.book.title}</p>
+                          {memory.book.author && <p style={{ color: 'var(--ink-light)', fontSize: '0.7rem', marginTop: '6px', margin: '6px 0 0' }}>{memory.book.author}</p>}
+                        </div>
+                  )}
+
                   <div style={{ color: 'var(--ink-faint)', fontSize: '0.7rem', marginTop: '6px', transform: `rotate(-${rotation}deg)` }}>
                     {memory.date}
                   </div>

--- a/src/app/components/MemoryDetailScreen.tsx
+++ b/src/app/components/MemoryDetailScreen.tsx
@@ -145,6 +145,33 @@ export function MemoryDetailScreen() {
               </p>
             </div>
           )}
+
+          {/* Book */}
+          {memory.type === 'book' && memory.book && (
+            <div style={{ display: 'flex', gap: '28px', alignItems: 'flex-start' }}>
+              {memory.book.cover_url && (
+                <img src={memory.book.cover_url} alt="" style={{ width: '120px', flexShrink: 0, boxShadow: '0 4px 16px var(--paper-shadow)', display: 'block' }} />
+              )}
+              <div style={{ flex: 1 }}>
+                <h3 style={{ color: 'var(--ink-text)', fontSize: '1.2rem', fontWeight: 400, margin: '0 0 6px', lineHeight: 1.4 }}>{memory.book.title}</h3>
+                {memory.book.author && (
+                  <p style={{ color: 'var(--ink-light)', fontSize: '0.875rem', margin: '0 0 20px' }}>{memory.book.author}</p>
+                )}
+                {memory.book.reading_notes && (
+                  <p style={{ color: 'var(--ink-text)', fontSize: '0.9rem', lineHeight: '1.9', margin: '0 0 20px', whiteSpace: 'pre-wrap' }}>{memory.book.reading_notes}</p>
+                )}
+                {memory.book.quotes && memory.book.quotes.length > 0 && (
+                  <div style={{ borderLeft: '2px solid var(--ink-faint)', paddingLeft: '16px', display: 'flex', flexDirection: 'column', gap: '14px' }}>
+                    {memory.book.quotes.map((q) => (
+                      <p key={q.id || q.order} style={{ color: 'var(--ink-light)', fontSize: '0.875rem', lineHeight: '1.8', margin: 0, fontStyle: 'italic' }}>
+                        {q.content}
+                      </p>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
         </motion.div>
       </div>
 

--- a/src/lib/bookSearchService.test.ts
+++ b/src/lib/bookSearchService.test.ts
@@ -4,96 +4,69 @@ import { searchBooks } from './bookSearchService'
 describe('searchBooks', () => {
   it('returns mapped results for a normal response', async () => {
     const mockResponse = {
-      docs: [
+      items: [
         {
-          title: 'The Great Gatsby',
-          author_name: ['F. Scott Fitzgerald'],
-          cover_i: 12345,
-          key: '/works/OL45804W',
+          id: 'abc123',
+          volumeInfo: {
+            title: 'The Great Gatsby',
+            authors: ['F. Scott Fitzgerald'],
+            imageLinks: { thumbnail: 'http://books.google.com/thumbnail/abc123' },
+          },
         },
         {
-          title: 'To Kill a Mockingbird',
-          author_name: ['Harper Lee'],
-          cover_i: undefined,
-          key: '/works/OL2798819W',
+          id: 'def456',
+          volumeInfo: {
+            title: '挪威的森林',
+            authors: ['村上春树'],
+            imageLinks: undefined,
+          },
         },
       ],
     }
 
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        json: () => Promise.resolve(mockResponse),
-      })
-    )
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: () => Promise.resolve(mockResponse) }))
 
     const results = await searchBooks('gatsby')
 
     expect(results).toHaveLength(2)
-
     expect(results[0]).toEqual({
       title: 'The Great Gatsby',
       author: 'F. Scott Fitzgerald',
-      coverUrl: 'https://covers.openlibrary.org/b/id/12345-M.jpg',
-      olid: 'OL45804W',
+      coverUrl: 'https://books.google.com/thumbnail/abc123', // http → https
+      id: 'abc123',
     })
-
     expect(results[1]).toEqual({
-      title: 'To Kill a Mockingbird',
-      author: 'Harper Lee',
+      title: '挪威的森林',
+      author: '村上春树',
       coverUrl: null,
-      olid: 'OL2798819W',
+      id: 'def456',
     })
 
     vi.unstubAllGlobals()
   })
 
-  it('returns empty array when docs is empty', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        json: () => Promise.resolve({ docs: [] }),
-      })
-    )
+  it('returns empty array when items is empty', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: () => Promise.resolve({ items: [] }) }))
 
     const results = await searchBooks('xyznonexistent')
-
     expect(results).toEqual([])
 
     vi.unstubAllGlobals()
   })
 
-  it('returns empty array for a nonexistent query without throwing', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        json: () => Promise.resolve({ docs: [] }),
-      })
-    )
+  it('returns empty array when items is missing', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) }))
 
-    let results: Awaited<ReturnType<typeof searchBooks>> | undefined
-    let error: unknown
-
-    try {
-      results = await searchBooks('zzzzzzzzzzzzzzzzzzzzzzz')
-    } catch (e) {
-      error = e
-    }
-
-    expect(error).toBeUndefined()
+    const results = await searchBooks('zzzzzzzzzzzzz')
     expect(results).toEqual([])
 
     vi.unstubAllGlobals()
   })
 
   it('returns empty array when fetch throws', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockRejectedValue(new Error('Network error'))
-    )
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')))
 
     const results = await searchBooks('anything')
-
     expect(results).toEqual([])
 
     vi.unstubAllGlobals()

--- a/src/lib/bookSearchService.ts
+++ b/src/lib/bookSearchService.ts
@@ -2,44 +2,53 @@ export interface BookSearchResult {
   title: string
   author: string
   coverUrl: string | null
-  olid: string // Open Library work ID, e.g. "OL45804W"
+  id: string // Google Books volume ID
 }
 
-interface OpenLibraryDoc {
-  title?: string
-  author_name?: string[]
-  cover_i?: number
-  key?: string
+interface GoogleBooksVolume {
+  id?: string
+  volumeInfo?: {
+    title?: string
+    authors?: string[]
+    imageLinks?: {
+      thumbnail?: string
+      smallThumbnail?: string
+    }
+  }
 }
 
-interface OpenLibraryResponse {
-  docs?: OpenLibraryDoc[]
+interface GoogleBooksResponse {
+  items?: GoogleBooksVolume[]
 }
 
 export async function searchBooks(query: string): Promise<BookSearchResult[]> {
-  try {
-    const url = `https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&limit=10&fields=title,author_name,cover_i,key`
-    const response = await fetch(url)
-    const data: OpenLibraryResponse = await response.json()
+  const apiKey = import.meta.env.VITE_GOOGLE_BOOKS_API_KEY
+  if (!apiKey) return []
 
-    if (!data.docs || data.docs.length === 0) {
+  try {
+    const url = `https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(query)}&maxResults=10&printType=books&key=${apiKey}`
+    const response = await fetch(url)
+    const data: GoogleBooksResponse = await response.json()
+
+    if (!data.items || data.items.length === 0) {
       return []
     }
 
-    return data.docs.map((doc) => {
-      const coverUrl = doc.cover_i
-        ? `https://covers.openlibrary.org/b/id/${doc.cover_i}-M.jpg`
-        : null
+    return data.items
+      .filter((item) => item.volumeInfo?.title)
+      .map((item) => {
+        const info = item.volumeInfo!
+        // Use https to avoid mixed content; Google returns http thumbnails
+        const thumbnail = info.imageLinks?.thumbnail ?? info.imageLinks?.smallThumbnail ?? null
+        const coverUrl = thumbnail ? thumbnail.replace('http://', 'https://') : null
 
-      const olid = doc.key ? doc.key.replace('/works/', '') : ''
-
-      return {
-        title: doc.title ?? '',
-        author: doc.author_name?.[0] ?? '',
-        coverUrl,
-        olid,
-      }
-    })
+        return {
+          title: info.title ?? '',
+          author: info.authors?.[0] ?? '',
+          coverUrl,
+          id: item.id ?? '',
+        }
+      })
   } catch {
     return []
   }

--- a/src/lib/memoryService.ts
+++ b/src/lib/memoryService.ts
@@ -2,6 +2,14 @@ import { supabase } from './supabaseClient'
 import { uploadImage } from './storageService'
 import type { Memory } from './types'
 
+export interface BookData {
+  title: string
+  author: string
+  coverUrl?: string | null
+  coverFile?: File
+  readingNotes?: string
+}
+
 function normalizeMemory(raw: any) {
   const photo = Array.isArray(raw.photo) ? raw.photo[0] ?? null : raw.photo
   const note = Array.isArray(raw.note) ? raw.note[0] ?? null : raw.note
@@ -132,4 +140,44 @@ export async function createNoteMemory(
   }
 
   return { ...memory, note: { memory_id: memory.id, note_type: noteType, content: content || null, images: uploadedImages } } as Memory
+}
+
+export async function createBookMemory(
+  locationId: string,
+  date: string,
+  book: BookData,
+  quotes: string[]
+): Promise<Memory> {
+  const { data: memory, error: memError } = await supabase
+    .from('memories')
+    .insert({ location_id: locationId, type: 'book', date })
+    .select()
+    .single()
+
+  if (memError) throw memError
+
+  let coverUrl = book.coverUrl ?? null
+  if (book.coverFile) {
+    const path = `books/${memory.id}-cover-${book.coverFile.name.replace(/\s+/g, '_')}`
+    coverUrl = await uploadImage(book.coverFile, path)
+  }
+
+  const { error: bookError } = await supabase
+    .from('memory_books')
+    .insert({ memory_id: memory.id, title: book.title, author: book.author, cover_url: coverUrl, reading_notes: book.readingNotes || null })
+
+  if (bookError) throw bookError
+
+  if (quotes.length > 0) {
+    const { error: quotesError } = await supabase
+      .from('book_quotes')
+      .insert(quotes.map((content, i) => ({ memory_id: memory.id, content, order: i })))
+
+    if (quotesError) throw quotesError
+  }
+
+  return {
+    ...memory,
+    book: { memory_id: memory.id, title: book.title, author: book.author, cover_url: coverUrl, reading_notes: book.readingNotes || null, quotes: quotes.map((content, i) => ({ id: '', memory_id: memory.id, content, order: i })) }
+  } as Memory
 }


### PR DESCRIPTION
## Parent issue

Closes #9

## Summary

- `createBookMemory` writes `memory_books` + `book_quotes`, supports OL cover URL or manual cover file upload
- `bookSearchService` switched to Google Books API (`VITE_GOOGLE_BOOKS_API_KEY`) for Chinese + foreign book support; fixes http→https on thumbnails
- `AddMemoryScreen`: book tab enabled — search dropdown with cover previews, manual entry fallback, reading notes, dynamic quotes list
- `LocationMemoryScreen`: book card shows cover image or title/author text card
- `MemoryDetailScreen`: book detail with cover, title, author, reading notes, quotes (left-border accent)

## Test plan

- [ ] Search a Chinese book — results appear with covers
- [ ] Search a foreign book — results appear
- [ ] Select from results — title/author/cover auto-fill
- [ ] Clear cover and upload manually
- [ ] Add/remove quote rows, submit — quotes saved to DB
- [ ] Location page shows book card
- [ ] Detail page shows all fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)