### PR TITLE
feat: 3-column masonry layout for location memory page

### DIFF
--- a/src/app/components/LocationMemoryScreen.tsx
+++ b/src/app/components/LocationMemoryScreen.tsx
@@ -4,9 +4,96 @@ import { motion } from 'motion/react';
 import { ArrowLeft } from 'lucide-react';
 import { getLocationById } from '../../lib/locationService';
 import { getMemoriesByLocation } from '../../lib/memoryService';
-import { getMemoryLayout } from '../../lib/pseudoRandom';
-import { StackedImages } from './StackedImages';
 import type { Location, Memory } from '../../lib/types';
+
+function MemoryCard({ memory, index }: { memory: Memory; index: number }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.15 + index * 0.05, duration: 0.5 }}
+      style={{ breakInside: 'avoid', marginBottom: '16px' }}
+    >
+      <Link to={`/memory/${memory.id}`} style={{ textDecoration: 'none', display: 'block' }} className="hover:opacity-80 transition-opacity">
+
+        {/* Photo */}
+        {memory.type === 'photo' && memory.photo && memory.photo.images.length > 0 && (
+          <div>
+            <img
+              src={memory.photo.images[0].image_url}
+              alt=""
+              style={{ width: '100%', height: '160px', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)', boxShadow: '0 2px 8px var(--paper-shadow)' }}
+            />
+            {(memory.photo.caption || memory.photo.images.length > 1) && (
+              <div style={{ padding: '8px 4px 0' }}>
+                {memory.photo.caption && (
+                  <p style={{ color: 'var(--ink-text)', fontSize: '0.8rem', margin: '0 0 2px', lineHeight: 1.5 }}>{memory.photo.caption}</p>
+                )}
+                {memory.photo.images.length > 1 && (
+                  <span style={{ color: 'var(--ink-faint)', fontSize: '0.72rem' }}>{memory.photo.images.length} 张</span>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Note: handwritten */}
+        {memory.type === 'note' && memory.note?.note_type === 'handwritten' && memory.note.images.length > 0 && (
+          <div>
+            <img
+              src={memory.note.images[0].image_url}
+              alt=""
+              style={{ width: '100%', height: '160px', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)', boxShadow: '0 2px 8px var(--paper-shadow)', border: '3px solid var(--paper-warm)' }}
+            />
+            {memory.note.content && (
+              <p style={{ color: 'var(--ink-light)', fontSize: '0.78rem', margin: '8px 4px 0', fontStyle: 'italic', lineHeight: 1.6 }}>
+                {memory.note.content}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Note: text */}
+        {memory.type === 'note' && memory.note?.note_type === 'text' && (
+          <div style={{ padding: '16px', background: 'var(--paper-warm)', boxShadow: '0 2px 8px var(--paper-shadow)', border: '1px solid rgba(58,54,50,0.08)' }}>
+            <p style={{ color: 'var(--ink-text)', fontSize: '0.82rem', lineHeight: 1.8, margin: 0, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 8, WebkitBoxOrient: 'vertical' }}>
+              {memory.note.content}
+            </p>
+          </div>
+        )}
+
+        {/* Book */}
+        {memory.type === 'book' && memory.book && (
+          <div style={{ background: 'var(--paper-warm)', boxShadow: '0 2px 8px var(--paper-shadow)', border: '1px solid rgba(58,54,50,0.08)' }}>
+            {memory.book.cover_url && (
+              <img src={memory.book.cover_url} alt="" style={{ width: '100%', height: '160px', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)' }} />
+            )}
+            <div style={{ padding: '12px 14px' }}>
+              <p style={{ color: 'var(--ink-text)', fontSize: '0.85rem', margin: '0 0 2px', fontWeight: 500 }}>{memory.book.title}</p>
+              {memory.book.author && (
+                <p style={{ color: 'var(--ink-light)', fontSize: '0.75rem', margin: '0 0 8px' }}>{memory.book.author}</p>
+              )}
+              {memory.book.reading_notes && (
+                <p style={{ color: 'var(--ink-light)', fontSize: '0.78rem', lineHeight: 1.7, margin: 0, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
+                  {memory.book.reading_notes}
+                </p>
+              )}
+              {!memory.book.reading_notes && memory.book.quotes?.[0] && (
+                <p style={{ color: 'var(--ink-faint)', fontSize: '0.78rem', lineHeight: 1.7, margin: 0, fontStyle: 'italic', overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
+                  {memory.book.quotes[0].content}
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+
+        <div style={{ color: 'var(--ink-faint)', fontSize: '0.7rem', marginTop: '5px', paddingLeft: '2px' }}>
+          {memory.date}
+        </div>
+      </Link>
+    </motion.div>
+  );
+}
 
 export function LocationMemoryScreen() {
   const { id } = useParams();
@@ -26,98 +113,42 @@ export function LocationMemoryScreen() {
   }, [id]);
 
   if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center" style={{ fontFamily: 'var(--font-serif)', color: 'var(--ink-faint)', fontSize: '0.875rem' }}>…</div>
-    );
+    return <div className="min-h-screen flex items-center justify-center" style={{ fontFamily: 'var(--font-serif)', color: 'var(--ink-faint)', fontSize: '0.875rem' }}>…</div>;
   }
 
   if (!location) {
-    return (
-      <div className="min-h-screen flex items-center justify-center" style={{ fontFamily: 'var(--font-serif)', color: 'var(--ink-faint)', fontSize: '0.875rem' }}>找不到这个地点</div>
-    );
+    return <div className="min-h-screen flex items-center justify-center" style={{ fontFamily: 'var(--font-serif)', color: 'var(--ink-faint)', fontSize: '0.875rem' }}>找不到这个地点</div>;
   }
 
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.8 }} className="min-h-screen p-6" style={{ fontFamily: 'var(--font-serif)' }}>
-      {/* Header */}
-      <div className="max-w-4xl mx-auto mb-12">
-        <Link to="/" style={{ color: 'var(--ink-light)', fontSize: '0.875rem' }} className="inline-flex items-center gap-2 mb-6 hover:opacity-70 transition-opacity">
-          <ArrowLeft size={16} /> 返回
-        </Link>
-        <div className="flex items-baseline justify-between">
-          <motion.h2 initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2, duration: 0.8 }} style={{ color: 'var(--ink-text)', fontSize: '1.5rem', fontWeight: 400, letterSpacing: '0.02em' }}>
-            {location.name}
-          </motion.h2>
-          <Link to={`/add?locationId=${id}`} style={{ color: 'var(--ink-faint)', fontSize: '0.8rem', textDecoration: 'none' }} className="hover:opacity-70 transition-opacity">
-            + 添加
+      <div className="max-w-3xl mx-auto">
+        {/* Header */}
+        <div className="mb-10">
+          <Link to="/" style={{ color: 'var(--ink-light)', fontSize: '0.875rem' }} className="inline-flex items-center gap-2 mb-6 hover:opacity-70 transition-opacity">
+            <ArrowLeft size={16} /> 返回
           </Link>
+          <div className="flex items-baseline justify-between">
+            <motion.h2 initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2, duration: 0.8 }} style={{ color: 'var(--ink-text)', fontSize: '1.5rem', fontWeight: 400, letterSpacing: '0.02em' }}>
+              {location.name}
+            </motion.h2>
+            <Link to={`/add?locationId=${id}`} style={{ color: 'var(--ink-faint)', fontSize: '0.8rem', textDecoration: 'none' }} className="hover:opacity-70 transition-opacity">
+              + 添加
+            </Link>
+          </div>
         </div>
-      </div>
 
-      {/* Memory space */}
-      <div className="max-w-4xl mx-auto relative" style={{ minHeight: '500px' }}>
+        {/* Masonry */}
         {memories.length === 0 ? (
           <motion.p initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.4, duration: 0.8 }} style={{ color: 'var(--ink-faint)', fontSize: '0.8rem', textAlign: 'center', marginTop: '80px' }}>
             还没有记忆
           </motion.p>
         ) : (
-          memories.map((memory, index) => {
-            const { x, y, rotation } = getMemoryLayout(memory.id);
-            return (
-              <motion.div
-                key={memory.id}
-                initial={{ opacity: 0, scale: 0.95 }}
-                animate={{ opacity: 1, scale: 1 }}
-                transition={{ delay: 0.3 + index * 0.1, duration: 0.6 }}
-                style={{ position: 'absolute', left: `${x}%`, top: `${y}%`, transform: `rotate(${rotation}deg)` }}
-              >
-                <Link to={`/memory/${memory.id}`} className="block hover:scale-105 transition-transform">
-                  {/* Photo */}
-                  {memory.type === 'photo' && memory.photo && (
-                    memory.photo.images.length > 1
-                      ? <StackedImages urls={memory.photo.images.map(i => i.image_url)} />
-                      : <div style={{ width: '160px', overflow: 'hidden', boxShadow: '0 2px 8px var(--paper-shadow)' }}>
-                          <img src={memory.photo.images[0]?.image_url} alt="" style={{ width: '100%', height: '200px', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)' }} />
-                        </div>
-                  )}
-
-                  {/* Note: handwritten */}
-                  {memory.type === 'note' && memory.note?.note_type === 'handwritten' && memory.note.images.length > 0 && (
-                    memory.note.images.length > 1
-                      ? <StackedImages urls={memory.note.images.map(i => i.image_url)} />
-                      : <div style={{ width: '160px', overflow: 'hidden', boxShadow: '0 2px 8px var(--paper-shadow)', border: '3px solid var(--paper-warm)' }}>
-                          <img src={memory.note.images[0].image_url} alt="" style={{ width: '100%', height: '200px', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)' }} />
-                        </div>
-                  )}
-
-                  {/* Note: text */}
-                  {memory.type === 'note' && memory.note?.note_type === 'text' && (
-                    <div style={{ width: '160px', minHeight: '120px', padding: '14px', background: 'var(--paper-warm)', boxShadow: '0 2px 8px var(--paper-shadow)', border: '1px solid rgba(58,54,50,0.08)' }}>
-                      <p style={{ color: 'var(--ink-text)', fontSize: '0.78rem', lineHeight: '1.7', margin: 0, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 6, WebkitBoxOrient: 'vertical' }}>
-                        {memory.note.content}
-                      </p>
-                    </div>
-                  )}
-
-                  {/* Book */}
-                  {memory.type === 'book' && memory.book && (
-                    memory.book.cover_url
-                      ? <div style={{ width: '110px', overflow: 'hidden', boxShadow: '0 2px 8px var(--paper-shadow)' }}>
-                          <img src={memory.book.cover_url} alt="" style={{ width: '100%', height: '150px', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)' }} />
-                        </div>
-                      : <div style={{ width: '110px', height: '150px', padding: '12px', background: 'var(--paper-warm)', boxShadow: '0 2px 8px var(--paper-shadow)', border: '1px solid rgba(58,54,50,0.08)', display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
-                          <p style={{ color: 'var(--ink-text)', fontSize: '0.78rem', lineHeight: '1.5', margin: 0 }}>{memory.book.title}</p>
-                          {memory.book.author && <p style={{ color: 'var(--ink-light)', fontSize: '0.7rem', marginTop: '6px', margin: '6px 0 0' }}>{memory.book.author}</p>}
-                        </div>
-                  )}
-
-                  <div style={{ color: 'var(--ink-faint)', fontSize: '0.7rem', marginTop: '6px', transform: `rotate(-${rotation}deg)` }}>
-                    {memory.date}
-                  </div>
-                </Link>
-              </motion.div>
-            );
-          })
+          <div style={{ columns: '3 160px', columnGap: '16px' }}>
+            {memories.map((memory, index) => (
+              <MemoryCard key={memory.id} memory={memory} index={index} />
+            ))}
+          </div>
         )}
       </div>
     </motion.div>


### PR DESCRIPTION
## Summary

- Replaced pseudo-random scattered (absolute positioning) layout with CSS `columns` masonry — 3 cols, min 160px each, auto-drops to fewer on narrow screens
- All images (photo, handwritten note, book cover) constrained to 160px height with `object-fit: cover`
- Each card shows content highlight: photo caption + count, note annotation, text excerpt (8 lines), book reading notes or first quote

## Test plan

- [ ] Location with mixed memory types renders in 3 columns
- [ ] Images are all consistent height, not distorted
- [ ] Cards flow naturally into shortest column
- [ ] Clicking any card navigates to detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)