### PR TITLE
feat: design refresh — LXGW WenKai, deeper palette, whitespace

### DIFF
--- a/src/app/components/AppLayout.tsx
+++ b/src/app/components/AppLayout.tsx
@@ -6,16 +6,17 @@ export function AppLayout() {
     <div className="min-h-screen flex flex-col" style={{ fontFamily: 'var(--font-serif)' }}>
       {/* Title */}
       <motion.div
-        initial={{ opacity: 0, y: 10 }}
+        initial={{ opacity: 0, y: 12 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.3, duration: 0.8 }}
-        className="text-center py-8 px-6"
+        transition={{ delay: 0.3, duration: 1 }}
+        className="text-center px-6"
+        style={{ paddingTop: '3.5rem', paddingBottom: '1.25rem' }}
       >
-        <h1 className="mb-2" style={{ color: 'var(--ink-text)', fontSize: '1.75rem', fontWeight: 400, letterSpacing: '0.02em' }}>
+        <h1 style={{ color: 'var(--ink-text)', fontSize: '2.25rem', fontWeight: 400, letterSpacing: '0.06em', margin: '0 0 0.5rem' }}>
           朝花夕拾
         </h1>
-        <p style={{ color: 'var(--ink-light)', fontSize: '0.875rem', fontWeight: 400 }}>
-          Dawn Blossoms Plucked at Dusk
+        <p style={{ color: 'var(--ink-faint)', fontSize: '0.8rem', fontWeight: 400, letterSpacing: '0.12em' }}>
+          DAWN BLOSSOMS PLUCKED AT DUSK
         </p>
       </motion.div>
 
@@ -23,8 +24,8 @@ export function AppLayout() {
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        transition={{ delay: 0.35, duration: 0.6 }}
-        style={{ display: 'flex', justifyContent: 'center', gap: '32px', marginBottom: '8px' }}
+        transition={{ delay: 0.45, duration: 0.8 }}
+        style={{ display: 'flex', justifyContent: 'center', gap: '40px', paddingBottom: '2rem' }}
       >
         {[{ to: '/', label: '地图', end: true }, { to: '/timeline', label: '时间线', end: false }].map(({ to, label, end }) => (
           <NavLink
@@ -33,7 +34,8 @@ export function AppLayout() {
             end={end}
             style={({ isActive }) => ({
               color: isActive ? 'var(--ink-text)' : 'var(--ink-faint)',
-              fontSize: '0.875rem',
+              fontSize: '0.8rem',
+              letterSpacing: '0.08em',
               textDecoration: 'none',
               paddingBottom: '4px',
               borderBottom: isActive ? '1px solid var(--ink-text)' : 'none',

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,1 +1,2 @@
 @import url('https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Lora:ital,wght@0,400;0,500;1,400&display=swap');
+@import url('https://cdn.jsdelivr.net/npm/lxgw-wenkai-webfont@1.7.0/lxgwwenkai-regular.css');

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -19,4 +19,6 @@ body::before {
 
 body {
   font-family: var(--font-serif);
+  line-height: 1.85;
+  -webkit-font-smoothing: antialiased;
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -2,17 +2,17 @@
 
 :root {
   /* Typography */
-  --font-serif: 'Crimson Text', 'Lora', Georgia, serif;
+  --font-serif: 'LXGW WenKai', 'Crimson Text', 'Lora', Georgia, serif;
   --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  
+
   /* Paper-like colors */
-  --paper-background: #f8f6f1;
-  --paper-bg: #f8f6f1;
-  --paper-warm: #faf8f3;
-  --ink-text: #3a3632;
-  --ink-light: #6b6561;
-  --ink-faint: #9a958f;
-  --paper-shadow: rgba(58, 54, 50, 0.08);
+  --paper-background: #f5f2eb;
+  --paper-bg: #f5f2eb;
+  --paper-warm: #f9f6ef;
+  --ink-text: #322e2a;
+  --ink-light: #635e59;
+  --ink-faint: #9a948d;
+  --paper-shadow: rgba(50, 46, 42, 0.13);
   
   /* Original theme variables */
   --font-size: 16px;


### PR DESCRIPTION
## Summary

- **字体**: 引入霞鹜文楷 (LXGW WenKai) 作为主字体，中文排版质量大幅提升；英文 fallback 保留 Crimson Text
- **颜色**: 背景加深至 `#f5f2eb`（更浓纸张感），卡片阴影从 0.08 加强到 0.13（层次更分明）
- **行高**: 全局 1.85，启用 antialiased 字体渲染
- **AppLayout**: 标题从 1.75rem 增至 2.25rem，副标题改为全大写 + 字间距，顶部留白增加 50%，tab 间距加大

## Test plan

- [ ] 中文文字显示为霞鹜文楷（楷体感，非宋体）
- [ ] 标题区域更大气、有留白
- [ ] 卡片阴影层次更明显
- [ ] 整体行距更舒展

🤖 Generated with [Claude Code](https://claude.com/claude-code)