### PR TITLE
feat: hierarchical locations with aggregated memory view

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -48,3 +48,9 @@ create table book_quotes (
 -- Storage: go to Supabase Dashboard → Storage → New bucket
 -- Name: memory-images
 -- Public bucket: true
+
+-- Migration: hierarchical locations
+-- Run in Supabase SQL Editor to add parent_id support:
+--
+-- ALTER TABLE locations
+--   ADD COLUMN parent_id uuid REFERENCES locations(id) ON DELETE SET NULL;

--- a/src/app/components/AddMemoryScreen.tsx
+++ b/src/app/components/AddMemoryScreen.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 import { motion, AnimatePresence } from 'motion/react';
 import { ArrowLeft, X, Plus, Minus } from 'lucide-react';
-import { getLocations } from '../../lib/locationService';
+import { getLocations, updateLocationParent } from '../../lib/locationService';
 import { createPhotoMemory, createNoteMemory, createBookMemory } from '../../lib/memoryService';
 import { createBook } from '../../lib/bookService';
 import { searchBooks } from '../../lib/bookSearchService';
@@ -392,6 +392,31 @@ export function AddMemoryScreen() {
               {locations.map((l) => <option key={l.id} value={l.id}>{l.name}</option>)}
             </select>
           </div>
+
+          {/* Parent location management (shown when a location is selected) */}
+          {locationId && (() => {
+            const selected = locations.find((l) => l.id === locationId);
+            if (!selected) return null;
+            return (
+              <div>
+                <label style={labelStyle}>「{selected.name}」的上属地点（可选）</label>
+                <select
+                  value={selected.parent_id ?? ''}
+                  onChange={async (e) => {
+                    const newParentId = e.target.value || null;
+                    await updateLocationParent(locationId, newParentId).catch(console.error);
+                    setLocations((prev) => prev.map((l) => l.id === locationId ? { ...l, parent_id: newParentId } : l));
+                  }}
+                  style={{ ...inputStyle, cursor: 'pointer' }}
+                >
+                  <option value="">无</option>
+                  {locations.filter((l) => l.id !== locationId).map((l) => (
+                    <option key={l.id} value={l.id}>{l.name}</option>
+                  ))}
+                </select>
+              </div>
+            );
+          })()}
 
           {/* Date */}
           <div>

--- a/src/app/components/EditMemoryScreen.tsx
+++ b/src/app/components/EditMemoryScreen.tsx
@@ -3,8 +3,9 @@ import { Link, useNavigate, useParams } from 'react-router';
 import { motion } from 'motion/react';
 import { ArrowLeft, X, Plus, Minus } from 'lucide-react';
 import { getMemoryById, updatePhotoMemory, updateNoteMemory, updateBookMemory } from '../../lib/memoryService';
+import { getLocations, updateLocationParent } from '../../lib/locationService';
 // BookData re-exported from memoryService for backwards compat
-import type { Memory, PhotoImage, NoteImage } from '../../lib/types';
+import type { Memory, PhotoImage, NoteImage, Location } from '../../lib/types';
 
 const inputStyle: React.CSSProperties = {
   width: '100%', padding: '10px 0', background: 'transparent', border: 'none',
@@ -21,6 +22,7 @@ export function EditMemoryScreen() {
   const { id } = useParams();
   const navigate = useNavigate();
   const [memory, setMemory] = useState<Memory | null>(null);
+  const [locations, setLocations] = useState<Location[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -55,6 +57,7 @@ export function EditMemoryScreen() {
   const coverInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    getLocations().then(setLocations).catch(console.error);
     getMemoryById(id!).then((m) => {
       if (!m) return;
       setMemory(m);
@@ -305,6 +308,31 @@ export function EditMemoryScreen() {
               </div>
             </>
           )}
+
+          {/* Parent location management */}
+          {memory.location_id && (() => {
+            const selected = locations.find((l) => l.id === memory.location_id);
+            if (!selected) return null;
+            return (
+              <div>
+                <label style={labelStyle}>「{selected.name}」的上属地点（可选）</label>
+                <select
+                  value={selected.parent_id ?? ''}
+                  onChange={async (e) => {
+                    const newParentId = e.target.value || null;
+                    await updateLocationParent(memory.location_id, newParentId).catch(console.error);
+                    setLocations((prev) => prev.map((l) => l.id === memory.location_id ? { ...l, parent_id: newParentId } : l));
+                  }}
+                  style={{ ...inputStyle, cursor: 'pointer' }}
+                >
+                  <option value="">无</option>
+                  {locations.filter((l) => l.id !== memory.location_id).map((l) => (
+                    <option key={l.id} value={l.id}>{l.name}</option>
+                  ))}
+                </select>
+              </div>
+            );
+          })()}
 
           {/* Date */}
           <div>

--- a/src/app/components/LocationMemoryScreen.tsx
+++ b/src/app/components/LocationMemoryScreen.tsx
@@ -1,12 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useParams, Link } from 'react-router';
 import { motion } from 'motion/react';
 import { ArrowLeft } from 'lucide-react';
-import { getLocationById } from '../../lib/locationService';
-import { getMemoriesByLocation } from '../../lib/memoryService';
+import {
+  getLocations,
+  getLocationById,
+  getAncestors,
+  getChildren,
+  getDescendantIds,
+} from '../../lib/locationService';
+import { getMemoriesByLocationTree } from '../../lib/memoryService';
 import type { Location, Memory } from '../../lib/types';
 
-function MemoryCard({ memory, index }: { memory: Memory; index: number }) {
+function MemoryCard({ memory, index, showLocation }: { memory: Memory; index: number; showLocation?: boolean }) {
   return (
     <motion.div
       initial={{ opacity: 0, y: 8 }}
@@ -20,6 +26,7 @@ function MemoryCard({ memory, index }: { memory: Memory; index: number }) {
         {memory.type === 'photo' && memory.photo && memory.photo.images.length > 0 && (
           <div>
             <img
+              loading="lazy"
               src={memory.photo.images[0].image_url}
               alt=""
               style={{ width: '100%', height: '160px', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)', boxShadow: '0 2px 8px var(--paper-shadow)' }}
@@ -41,6 +48,7 @@ function MemoryCard({ memory, index }: { memory: Memory; index: number }) {
         {memory.type === 'note' && memory.note?.note_type === 'handwritten' && memory.note.images.length > 0 && (
           <div>
             <img
+              loading="lazy"
               src={memory.note.images[0].image_url}
               alt=""
               style={{ width: '100%', height: '160px', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)', boxShadow: '0 2px 8px var(--paper-shadow)', border: '3px solid var(--paper-warm)' }}
@@ -66,7 +74,7 @@ function MemoryCard({ memory, index }: { memory: Memory; index: number }) {
         {memory.type === 'book' && memory.book && (
           <div style={{ background: 'var(--paper-warm)', boxShadow: '0 2px 8px var(--paper-shadow)', border: '1px solid rgba(58,54,50,0.08)' }}>
             {memory.book.cover_url && (
-              <img src={memory.book.cover_url} alt="" style={{ width: '100%', height: '160px', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)' }} />
+              <img loading="lazy" src={memory.book.cover_url} alt="" style={{ width: '100%', height: '160px', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)' }} />
             )}
             <div style={{ padding: '12px 14px' }}>
               <p style={{ color: 'var(--ink-text)', fontSize: '0.85rem', margin: '0 0 2px', fontWeight: 500 }}>{memory.book.title}</p>
@@ -87,30 +95,98 @@ function MemoryCard({ memory, index }: { memory: Memory; index: number }) {
           </div>
         )}
 
-        <div style={{ color: 'var(--ink-faint)', fontSize: '0.7rem', marginTop: '5px', paddingLeft: '2px' }}>
-          {memory.date}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginTop: '5px', paddingLeft: '2px' }}>
+          <span style={{ color: 'var(--ink-faint)', fontSize: '0.7rem' }}>{memory.date}</span>
+          {showLocation && (memory as any).location?.name && (
+            <span style={{ color: 'var(--ink-faint)', fontSize: '0.68rem' }}>{(memory as any).location.name}</span>
+          )}
         </div>
       </Link>
     </motion.div>
   );
 }
 
+const filterBtnStyle = (active: boolean): React.CSSProperties => ({
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  fontFamily: 'var(--font-serif)',
+  fontSize: '0.78rem',
+  color: active ? 'var(--ink-text)' : 'var(--ink-faint)',
+  paddingBottom: '2px',
+  borderBottom: active ? '1px solid var(--ink-text)' : 'none',
+  transition: 'all 0.2s',
+});
+
 export function LocationMemoryScreen() {
   const { id } = useParams();
+  const [allLocations, setAllLocations] = useState<Location[]>([]);
   const [location, setLocation] = useState<Location | null>(null);
-  const [memories, setMemories] = useState<Memory[]>([]);
+  const [allMemories, setAllMemories] = useState<Memory[]>([]);
   const [loading, setLoading] = useState(true);
+  const [typeFilter, setTypeFilter] = useState<'all' | 'photo' | 'note' | 'book'>('all');
+  const [subFilter, setSubFilter] = useState<string>('all'); // 'all' | locationId
 
   useEffect(() => {
-    getLocationById(id!)
-      .then(setLocation)
+    setLoading(true);
+    setTypeFilter('all');
+    setSubFilter('all');
+
+    Promise.all([getLocations(), getLocationById(id!)])
+      .then(async ([locs, loc]) => {
+        setAllLocations(locs);
+        setLocation(loc);
+        if (loc) {
+          const descendantIds = getDescendantIds(locs, loc.id);
+          const allIds = [loc.id, ...descendantIds];
+          const memories = await getMemoriesByLocationTree(allIds);
+          setAllMemories(memories);
+        }
+      })
       .catch(console.error)
       .finally(() => setLoading(false));
-
-    getMemoriesByLocation(id!)
-      .then(setMemories)
-      .catch(console.error);
   }, [id]);
+
+  const ancestors = useMemo(
+    () => location ? getAncestors(allLocations, location.id) : [],
+    [allLocations, location]
+  );
+
+  const children = useMemo(
+    () => location ? getChildren(allLocations, location.id) : [],
+    [allLocations, location]
+  );
+
+  // Count all tree memories per child (for the chips)
+  const childMemoryCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const child of children) {
+      const childDescendantIds = getDescendantIds(allLocations, child.id);
+      const childIds = new Set([child.id, ...childDescendantIds]);
+      counts[child.id] = allMemories.filter((m) => childIds.has(m.location_id)).length;
+    }
+    return counts;
+  }, [children, allLocations, allMemories]);
+
+  const filteredMemories = useMemo(() => {
+    let result = allMemories;
+
+    // Sub-location filter
+    if (subFilter !== 'all') {
+      const subDescendantIds = getDescendantIds(allLocations, subFilter);
+      const subIds = new Set([subFilter, ...subDescendantIds]);
+      result = result.filter((m) => subIds.has(m.location_id));
+    }
+
+    // Type filter
+    if (typeFilter !== 'all') {
+      result = result.filter((m) => m.type === typeFilter);
+    }
+
+    return result;
+  }, [allMemories, subFilter, typeFilter, allLocations]);
+
+  const showLocationBadge = subFilter === 'all' && children.length > 0;
 
   if (loading) {
     return <div className="min-h-screen flex items-center justify-center" style={{ fontFamily: 'var(--font-serif)', color: 'var(--ink-faint)', fontSize: '0.875rem' }}>…</div>;
@@ -123,11 +199,25 @@ export function LocationMemoryScreen() {
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.8 }} className="min-h-screen p-6" style={{ fontFamily: 'var(--font-serif)' }}>
       <div className="max-w-3xl mx-auto">
+
         {/* Header */}
-        <div className="mb-10">
-          <Link to="/" style={{ color: 'var(--ink-light)', fontSize: '0.875rem' }} className="inline-flex items-center gap-2 mb-6 hover:opacity-70 transition-opacity">
-            <ArrowLeft size={16} /> 返回
-          </Link>
+        <div className="mb-8">
+          {/* Breadcrumb */}
+          <div className="flex items-center gap-1 mb-6 flex-wrap" style={{ fontSize: '0.875rem', color: 'var(--ink-light)' }}>
+            {ancestors.length > 0 ? (
+              ancestors.map((a, i) => (
+                <span key={a.id} className="inline-flex items-center gap-1">
+                  <Link to={`/location/${a.id}`} style={{ color: 'var(--ink-light)' }} className="hover:opacity-70 transition-opacity">{a.name}</Link>
+                  <span style={{ color: 'var(--ink-faint)' }}>›</span>
+                </span>
+              ))
+            ) : (
+              <Link to="/" style={{ color: 'var(--ink-light)' }} className="inline-flex items-center gap-2 hover:opacity-70 transition-opacity">
+                <ArrowLeft size={16} /> 返回
+              </Link>
+            )}
+          </div>
+
           <div className="flex items-baseline justify-between">
             <motion.h2 initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2, duration: 0.8 }} style={{ color: 'var(--ink-text)', fontSize: '1.5rem', fontWeight: 400, letterSpacing: '0.02em' }}>
               {location.name}
@@ -138,15 +228,80 @@ export function LocationMemoryScreen() {
           </div>
         </div>
 
-        {/* Masonry */}
-        {memories.length === 0 ? (
+        {/* Sub-locations */}
+        {children.length > 0 && (
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.3, duration: 0.6 }} className="mb-8">
+            <p style={{ color: 'var(--ink-faint)', fontSize: '0.72rem', letterSpacing: '0.05em', marginBottom: '10px' }}>下属地点</p>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+              {children.map((child) => (
+                <Link
+                  key={child.id}
+                  to={`/location/${child.id}`}
+                  style={{
+                    padding: '5px 12px',
+                    border: '1px solid var(--ink-faint)',
+                    color: 'var(--ink-text)',
+                    fontSize: '0.8rem',
+                    textDecoration: 'none',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                  }}
+                  className="hover:opacity-70 transition-opacity"
+                >
+                  {child.name}
+                  {childMemoryCounts[child.id] > 0 && (
+                    <span style={{ color: 'var(--ink-faint)', fontSize: '0.7rem' }}>
+                      {childMemoryCounts[child.id]}
+                    </span>
+                  )}
+                </Link>
+              ))}
+            </div>
+          </motion.div>
+        )}
+
+        {/* Filter bar */}
+        {allMemories.length > 0 && (
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.35, duration: 0.6 }} className="flex items-center gap-6 mb-6 flex-wrap">
+            {/* Type filter */}
+            <div className="flex items-center gap-4">
+              {(['all', 'photo', 'note', 'book'] as const).map((t) => (
+                <button key={t} onClick={() => setTypeFilter(t)} style={filterBtnStyle(typeFilter === t)}>
+                  {t === 'all' ? '全部' : t === 'photo' ? '照片' : t === 'note' ? '笔记' : '书籍'}
+                </button>
+              ))}
+            </div>
+
+            {/* Sub-location filter */}
+            {children.length > 0 && (
+              <div className="flex items-center gap-4" style={{ borderLeft: '1px solid var(--ink-faint)', paddingLeft: '16px' }}>
+                <button onClick={() => setSubFilter('all')} style={filterBtnStyle(subFilter === 'all')}>所有下属</button>
+                <button
+                  onClick={() => setSubFilter(location.id)}
+                  style={filterBtnStyle(subFilter === location.id)}
+                >
+                  仅本地
+                </button>
+                {children.map((child) => (
+                  <button key={child.id} onClick={() => setSubFilter(child.id)} style={filterBtnStyle(subFilter === child.id)}>
+                    {child.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </motion.div>
+        )}
+
+        {/* Memory grid */}
+        {filteredMemories.length === 0 ? (
           <motion.p initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.4, duration: 0.8 }} style={{ color: 'var(--ink-faint)', fontSize: '0.8rem', textAlign: 'center', marginTop: '80px' }}>
             还没有记忆
           </motion.p>
         ) : (
           <div style={{ columns: '3 160px', columnGap: '16px' }}>
-            {memories.map((memory, index) => (
-              <MemoryCard key={memory.id} memory={memory} index={index} />
+            {filteredMemories.map((memory, index) => (
+              <MemoryCard key={memory.id} memory={memory} index={index} showLocation={showLocationBadge} />
             ))}
           </div>
         )}

--- a/src/app/components/MapScreen.tsx
+++ b/src/app/components/MapScreen.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router';
 import { motion, AnimatePresence } from 'motion/react';
 import { MapContainer, TileLayer, Marker, Popup, useMapEvents } from 'react-leaflet';
 import L from 'leaflet';
-import { getLocations, createLocation, searchByName } from '../../lib/locationService';
+import { getLocations, createLocation, searchByName, suggestParentFromDisplayName } from '../../lib/locationService';
 import { getMemoriesByLocation } from '../../lib/memoryService';
 import type { Location, Memory, NominatimResult } from '../../lib/types';
 
@@ -21,6 +21,14 @@ const inkIcon = new L.DivIcon({
   html: `<div style="width:10px;height:10px;border-radius:50%;background:#3a3632;opacity:0.75;box-shadow:0 0 0 4px rgba(58,54,50,0.15)"></div>`,
   iconSize: [10, 10],
   iconAnchor: [5, 5],
+});
+
+// Hollow marker for parent locations (those that have children)
+const parentInkIcon = new L.DivIcon({
+  className: '',
+  html: `<div style="width:14px;height:14px;border-radius:50%;background:transparent;border:2px solid rgba(58,54,50,0.75);box-shadow:0 0 0 4px rgba(58,54,50,0.1)"></div>`,
+  iconSize: [14, 14],
+  iconAnchor: [7, 7],
 });
 
 function pickRandom<T>(arr: T[]): T | null {
@@ -55,11 +63,13 @@ function getRandomPhoto(memories: Memory[]): string | null {
 
 function LocationMarker({
   location,
+  isParent,
   cache,
   onLoad,
   onNavigate,
 }: {
   location: Location;
+  isParent: boolean;
   cache: Record<string, Memory[]>;
   onLoad: (id: string, memories: Memory[]) => void;
   onNavigate: (id: string) => void;
@@ -87,7 +97,7 @@ function LocationMarker({
     <Marker
       ref={markerRef}
       position={[location.lat, location.lng]}
-      icon={inkIcon}
+      icon={isParent ? parentInkIcon : inkIcon}
       eventHandlers={{
         mouseover: handleMouseOver,
         mouseout: handleMouseOut,
@@ -131,6 +141,8 @@ export function MapScreen() {
   const [memoriesCache, setMemoriesCache] = useState<Record<string, Memory[]>>({});
   const [pending, setPending] = useState<{ lat: number; lng: number } | null>(null);
   const [locationName, setLocationName] = useState('');
+  const [parentId, setParentId] = useState<string>('');
+  const [suggestedParent, setSuggestedParent] = useState<Location | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<NominatimResult[]>([]);
   const [saving, setSaving] = useState(false);
@@ -148,6 +160,8 @@ export function MapScreen() {
   function handleMapClick(lat: number, lng: number) {
     setPending({ lat, lng });
     setLocationName('');
+    setParentId('');
+    setSuggestedParent(null);
   }
 
   function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -165,6 +179,9 @@ export function MapScreen() {
     setSearchResults([]);
     setPending({ lat: result.lat, lng: result.lng });
     setLocationName(result.name);
+    setParentId('');
+    const suggested = suggestParentFromDisplayName(result.displayName, locations);
+    setSuggestedParent(suggested);
     setTimeout(() => nameInputRef.current?.focus(), 50);
   }
 
@@ -172,10 +189,13 @@ export function MapScreen() {
     if (!pending || !locationName.trim()) return;
     setSaving(true);
     try {
-      const newLocation = await createLocation(locationName.trim(), pending.lat, pending.lng);
+      const resolvedParentId = parentId || (suggestedParent ? suggestedParent.id : null);
+      const newLocation = await createLocation(locationName.trim(), pending.lat, pending.lng, resolvedParentId);
       setLocations((prev) => [...prev, newLocation]);
       setPending(null);
       setLocationName('');
+      setParentId('');
+      setSuggestedParent(null);
     } catch (err) {
       console.error(err);
     } finally {
@@ -278,6 +298,7 @@ export function MapScreen() {
               <LocationMarker
                 key={location.id}
                 location={location}
+                isParent={locations.some((l) => l.parent_id === location.id)}
                 cache={memoriesCache}
                 onLoad={(id, mems) => setMemoriesCache((prev) => ({ ...prev, [id]: mems }))}
                 onNavigate={(id) => { window.location.href = `/location/${id}`; }}
@@ -334,9 +355,33 @@ export function MapScreen() {
                   width: '100%', padding: '6px 0', background: 'transparent',
                   border: 'none', borderBottom: '1px solid var(--ink-faint)',
                   color: 'var(--ink-text)', fontSize: '1rem', fontFamily: 'var(--font-serif)',
-                  outline: 'none', marginBottom: '24px',
+                  outline: 'none', marginBottom: '20px',
                 }}
               />
+              {/* Nominatim parent suggestion */}
+              {suggestedParent && !parentId && (
+                <div style={{ marginBottom: '16px', padding: '8px 10px', border: '1px solid var(--ink-faint)', fontSize: '0.78rem', color: 'var(--ink-light)' }}>
+                  检测到上属地点「{suggestedParent.name}」，是否设置？
+                  <div style={{ marginTop: '6px', display: 'flex', gap: '12px' }}>
+                    <button onClick={() => setParentId(suggestedParent.id)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--ink-text)', fontSize: '0.78rem', fontFamily: 'var(--font-serif)', borderBottom: '1px solid var(--ink-text)', paddingBottom: '1px' }}>是</button>
+                    <button onClick={() => setSuggestedParent(null)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--ink-faint)', fontSize: '0.78rem', fontFamily: 'var(--font-serif)' }}>否</button>
+                  </div>
+                </div>
+              )}
+              {/* Manual parent selector */}
+              <div style={{ marginBottom: '24px' }}>
+                <p style={{ color: 'var(--ink-faint)', fontSize: '0.72rem', marginBottom: '6px', letterSpacing: '0.05em' }}>上属地点（可选）</p>
+                <select
+                  value={parentId}
+                  onChange={(e) => { setParentId(e.target.value); setSuggestedParent(null); }}
+                  style={{ width: '100%', padding: '6px 0', background: 'transparent', border: 'none', borderBottom: '1px solid var(--ink-faint)', color: 'var(--ink-text)', fontSize: '0.875rem', fontFamily: 'var(--font-serif)', outline: 'none', cursor: 'pointer' }}
+                >
+                  <option value="">无</option>
+                  {locations.map((l) => (
+                    <option key={l.id} value={l.id}>{l.name}</option>
+                  ))}
+                </select>
+              </div>
               <div style={{ display: 'flex', gap: '16px', justifyContent: 'flex-end' }}>
                 <button
                   onClick={() => setPending(null)}

--- a/src/lib/locationService.ts
+++ b/src/lib/locationService.ts
@@ -11,10 +11,15 @@ export async function getLocations(): Promise<Location[]> {
   return data
 }
 
-export async function createLocation(name: string, lat: number, lng: number): Promise<Location> {
+export async function createLocation(
+  name: string,
+  lat: number,
+  lng: number,
+  parentId?: string | null
+): Promise<Location> {
   const { data, error } = await supabase
     .from('locations')
-    .insert({ name, lat, lng })
+    .insert({ name, lat, lng, parent_id: parentId ?? null })
     .select()
     .single()
 
@@ -31,6 +36,70 @@ export async function getLocationById(id: string): Promise<Location | null> {
 
   if (error) return null
   return data
+}
+
+export async function updateLocationParent(
+  locationId: string,
+  parentId: string | null
+): Promise<void> {
+  const { error } = await supabase
+    .from('locations')
+    .update({ parent_id: parentId })
+    .eq('id', locationId)
+  if (error) throw error
+}
+
+// --- Client-side tree helpers (operate on the flat locations array) ---
+
+/** Returns ancestors ordered from root → direct parent */
+export function getAncestors(allLocations: Location[], locationId: string): Location[] {
+  const locMap = new Map(allLocations.map((l) => [l.id, l]))
+  const ancestors: Location[] = []
+  let current = locMap.get(locationId)
+  while (current?.parent_id) {
+    const parent = locMap.get(current.parent_id)
+    if (!parent) break
+    ancestors.unshift(parent)
+    current = parent
+  }
+  return ancestors
+}
+
+/** Returns immediate children of a location */
+export function getChildren(allLocations: Location[], parentId: string): Location[] {
+  return allLocations.filter((l) => l.parent_id === parentId)
+}
+
+/** Returns all descendant IDs (not including rootId itself) via BFS */
+export function getDescendantIds(allLocations: Location[], rootId: string): string[] {
+  const ids: string[] = []
+  const queue = [rootId]
+  while (queue.length) {
+    const current = queue.shift()!
+    for (const loc of allLocations) {
+      if (loc.parent_id === current) {
+        ids.push(loc.id)
+        queue.push(loc.id)
+      }
+    }
+  }
+  return ids
+}
+
+/** Given a Nominatim displayName like "San Francisco, California, United States",
+ *  returns the first existing location in DB that matches any component (skipping index 0). */
+export function suggestParentFromDisplayName(
+  displayName: string,
+  locations: Location[]
+): Location | null {
+  const parts = displayName.split(',').map((p) => p.trim())
+  for (let i = 1; i < parts.length; i++) {
+    const match = locations.find(
+      (l) => l.name.toLowerCase() === parts[i].toLowerCase()
+    )
+    if (match) return match
+  }
+  return null
 }
 
 export async function searchByName(query: string): Promise<NominatimResult[]> {

--- a/src/lib/memoryService.ts
+++ b/src/lib/memoryService.ts
@@ -39,6 +39,18 @@ const MEMORY_SELECT = `
   book_link:memory_books(book:books(*, quotes:book_quotes(*)))
 `
 
+export async function getMemoriesByLocationTree(locationIds: string[]): Promise<Memory[]> {
+  if (locationIds.length === 0) return []
+  const { data, error } = await supabase
+    .from('memories')
+    .select(`${MEMORY_SELECT}, location:locations(name)`)
+    .in('location_id', locationIds)
+    .order('date', { ascending: false })
+
+  if (error) throw error
+  return (data as any[]).map(normalizeMemory) as Memory[]
+}
+
 export async function getMemoriesByLocation(locationId: string): Promise<Memory[]> {
   const { data, error } = await supabase
     .from('memories')

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,7 @@ export interface Location {
   name: string
   lat: number
   lng: number
+  parent_id: string | null
   created_at: string
 }
 


### PR DESCRIPTION
## Parent issue

Closes #30

## Summary

- `parent_id` self-reference on `locations` table (migration SQL in `schema.sql`)
- Client-side tree helpers: `getAncestors`, `getChildren`, `getDescendantIds`, `suggestParentFromDisplayName`
- `getMemoriesByLocationTree` aggregates memories across an entire location subtree
- **LocationMemoryScreen**: clickable breadcrumb, sub-location chips with counts, type + sub-location filter, shows all descendant memories by default (with location badge on each card)
- **MapScreen**: hollow pin for parent locations, parent dropdown in creation dialog, Nominatim auto-suggest for parent
- **AddMemoryScreen / EditMemoryScreen**: inline parent assignment for the selected location

## ⚠️ Required before testing

Run in Supabase SQL Editor:

```sql
ALTER TABLE locations
  ADD COLUMN parent_id uuid REFERENCES locations(id) ON DELETE SET NULL;
```

## Test plan

- [ ] Run the migration SQL in Supabase
- [ ] Create a parent location (e.g. "United States") on the map — pin should be hollow after a child is added
- [ ] Create a child location with parent set to "United States" — breadcrumb shows on its page
- [ ] Navigate to "United States" — see child chips + all descendant memories
- [ ] Use sub-location filter to narrow to a specific child
- [ ] Use type filter (photo/note/book) combined with sub-location filter
- [ ] Select a search result in MapScreen — check Nominatim parent suggestion appears if match found
- [ ] Edit a memory → change the location's parent inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)