### PR TITLE
perf: add lazy loading to image tags

### DIFF
--- a/src/app/components/StackedImages.tsx
+++ b/src/app/components/StackedImages.tsx
@@ -33,6 +33,7 @@ export function StackedImages({ urls, width = 160, height = 200 }: StackedImages
             <img
               src={url}
               alt=""
+              loading="lazy"
               style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block', filter: 'contrast(0.92) saturate(0.85)' }}
             />
           </div>

--- a/src/app/components/TimelineScreen.tsx
+++ b/src/app/components/TimelineScreen.tsx
@@ -19,6 +19,7 @@ function MemoryThumbnail({ memory }: { memory: Memory }) {
       <img
         src={memory.photo.images[0].image_url}
         alt={memory.photo.caption ?? '照片'}
+        loading="lazy"
         style={thumbStyle}
       />
     );
@@ -30,6 +31,7 @@ function MemoryThumbnail({ memory }: { memory: Memory }) {
         <img
           src={memory.note.images[0].image_url}
           alt="手写笔记"
+          loading="lazy"
           style={thumbStyle}
         />
       );
@@ -66,6 +68,7 @@ function MemoryThumbnail({ memory }: { memory: Memory }) {
         <img
           src={memory.book.cover_url}
           alt={memory.book.title}
+          loading="lazy"
           style={thumbStyle}
         />
       );


### PR DESCRIPTION
## Parent issue

Closes #27

## Summary

- `loading="lazy"` added to all list-view image tags (StackedImages, TimelineScreen)
- LocationMemoryScreen already covered in a previous commit
- No quality or visual change — browser defers loading offscreen images

## Test plan

- [ ] Open a location with many memories — images below the fold should load only as you scroll
- [ ] Timeline screen — thumbnails lazy-load on scroll
- [ ] No visual regression on any image

🤖 Generated with [Claude Code](https://claude.com/claude-code)