### PR TITLE
feat: add location to books and enlarge photo frame

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -54,3 +54,16 @@ create table book_quotes (
 --
 -- ALTER TABLE locations
 --   ADD COLUMN parent_id uuid REFERENCES locations(id) ON DELETE SET NULL;
+
+-- Migration: add location to books (direct location association)
+-- Run in Supabase SQL Editor:
+--
+-- ALTER TABLE books
+--   ADD COLUMN location_id UUID REFERENCES locations(id) ON DELETE SET NULL;
+
+-- Migration: video support in photo memories
+-- Run in Supabase SQL Editor:
+--
+-- ALTER TABLE photo_images
+--   ADD COLUMN media_type TEXT NOT NULL DEFAULT 'image',
+--   ADD COLUMN video_url  TEXT;

--- a/src/app/components/BookDetailScreen.tsx
+++ b/src/app/components/BookDetailScreen.tsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router';
 import { motion } from 'motion/react';
 import { ArrowLeft, Minus, Plus, X } from 'lucide-react';
-import { getBookById, updateBook, deleteBook, getLinkedMemories } from '../../lib/bookService';
+import { getBookById, updateBook, deleteBook, getLinkedMemories, updateBookLocation } from '../../lib/bookService';
 import { searchBooks } from '../../lib/bookSearchService';
 import type { BookSearchResult } from '../../lib/bookSearchService';
 import { AnimatePresence } from 'motion/react';
 import { useRef } from 'react';
-import type { Book } from '../../lib/types';
+import type { Book, Location } from '../../lib/types';
+import { LocationPickerSheet } from './LocationPickerSheet';
 
 const inputStyle: React.CSSProperties = {
   width: '100%', padding: '10px 0', background: 'transparent', border: 'none',
@@ -33,6 +34,7 @@ export function BookDetailScreen() {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState('');
+  const [showLocationPicker, setShowLocationPicker] = useState(false);
 
   // Edit state
   const [bookTitle, setBookTitle] = useState('');
@@ -103,6 +105,18 @@ export function BookDetailScreen() {
     setBookCoverUrl(null);
     setBookCoverPreview(URL.createObjectURL(file));
     e.target.value = '';
+  }
+
+  async function handleSelectLocation(loc: Location) {
+    if (!book) return;
+    await updateBookLocation(book.id, loc.id);
+    setBook({ ...book, location_id: loc.id, location: loc });
+  }
+
+  async function handleRemoveLocation() {
+    if (!book) return;
+    await updateBookLocation(book.id, null);
+    setBook({ ...book, location_id: null, location: undefined });
   }
 
   async function handleSave() {
@@ -339,6 +353,45 @@ export function BookDetailScreen() {
               </div>
             </div>
 
+            {/* Location */}
+            {(() => {
+              const directLoc = book.location;
+              const fallbackLoc = !directLoc ? linkedMemories[0]?.memory?.location : null;
+              if (directLoc) {
+                return (
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '28px' }}>
+                    <Link
+                      to={`/location/${book.location_id}`}
+                      style={{ color: 'var(--ink-light)', fontSize: '0.85rem', textDecoration: 'none' }}
+                      className="hover:opacity-70 transition-opacity"
+                    >
+                      {directLoc.name}
+                    </Link>
+                    <button onClick={() => setShowLocationPicker(true)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--ink-faint)', fontSize: '0.75rem', fontFamily: 'var(--font-serif)', padding: 0 }} className="hover:opacity-70 transition-opacity">
+                      更改
+                    </button>
+                    <button onClick={handleRemoveLocation} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--ink-faint)', fontSize: '0.75rem', fontFamily: 'var(--font-serif)', padding: 0 }} className="hover:opacity-70 transition-opacity">
+                      移除
+                    </button>
+                  </div>
+                );
+              }
+              if (fallbackLoc) {
+                return (
+                  <div style={{ marginBottom: '28px' }}>
+                    <span style={{ color: 'var(--ink-light)', fontSize: '0.85rem' }}>{fallbackLoc.name}</span>
+                  </div>
+                );
+              }
+              return (
+                <div style={{ marginBottom: '28px' }}>
+                  <button onClick={() => setShowLocationPicker(true)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--ink-faint)', fontSize: '0.8rem', fontFamily: 'var(--font-serif)', padding: 0 }} className="hover:opacity-70 transition-opacity">
+                    + 添加阅读地点
+                  </button>
+                </div>
+              );
+            })()}
+
             {book.reading_notes && (
               <div style={{ marginBottom: '36px' }}>
                 <p style={{ color: 'var(--ink-text)', fontSize: '0.9rem', lineHeight: '1.9', margin: 0, whiteSpace: 'pre-wrap' }}>
@@ -383,6 +436,13 @@ export function BookDetailScreen() {
           </motion.div>
         )}
       </div>
+
+      <LocationPickerSheet
+        open={showLocationPicker}
+        onClose={() => setShowLocationPicker(false)}
+        onSelect={handleSelectLocation}
+        currentLocationId={book?.location_id}
+      />
     </motion.div>
   );
 }

--- a/src/app/components/LocationMemoryScreen.tsx
+++ b/src/app/components/LocationMemoryScreen.tsx
@@ -10,9 +10,25 @@ import {
   getDescendantIds,
 } from '../../lib/locationService';
 import { getMemoriesByLocationTree } from '../../lib/memoryService';
-import type { Location, Memory } from '../../lib/types';
+import { getBooksByLocationIds } from '../../lib/bookService';
+import type { Location, Memory, Book } from '../../lib/types';
 
-function MemoryCard({ memory, index, showLocation }: { memory: Memory; index: number; showLocation?: boolean }) {
+type DisplayItem = Memory & { _to?: string }
+
+function bookToDisplayItem(book: Book): DisplayItem {
+  return {
+    id: `book-${book.id}`,
+    location_id: book.location_id!,
+    type: 'book',
+    date: book.read_date ?? book.created_at.slice(0, 10),
+    created_at: book.created_at,
+    book,
+    _to: `/book/${book.id}`,
+  }
+}
+
+function MemoryCard({ memory, index, showLocation, to }: { memory: Memory; index: number; showLocation?: boolean; to?: string }) {
+  const linkTo = to ?? `/memory/${memory.id}`;
   return (
     <motion.div
       initial={{ opacity: 0, y: 8 }}
@@ -20,7 +36,7 @@ function MemoryCard({ memory, index, showLocation }: { memory: Memory; index: nu
       transition={{ delay: 0.15 + index * 0.05, duration: 0.5 }}
       style={{ breakInside: 'avoid', marginBottom: '16px' }}
     >
-      <Link to={`/memory/${memory.id}`} style={{ textDecoration: 'none', display: 'block' }} className="hover:opacity-80 transition-opacity">
+      <Link to={linkTo} style={{ textDecoration: 'none', display: 'block' }} className="hover:opacity-80 transition-opacity">
 
         {/* Photo */}
         {memory.type === 'photo' && memory.photo && memory.photo.images.length > 0 && (
@@ -123,6 +139,7 @@ export function LocationMemoryScreen() {
   const [allLocations, setAllLocations] = useState<Location[]>([]);
   const [location, setLocation] = useState<Location | null>(null);
   const [allMemories, setAllMemories] = useState<Memory[]>([]);
+  const [locationBooks, setLocationBooks] = useState<Book[]>([]);
   const [loading, setLoading] = useState(true);
   const [typeFilter, setTypeFilter] = useState<'all' | 'photo' | 'note' | 'book'>('all');
   const [subFilter, setSubFilter] = useState<string>('all'); // 'all' | locationId
@@ -139,8 +156,12 @@ export function LocationMemoryScreen() {
         if (loc) {
           const descendantIds = getDescendantIds(locs, loc.id);
           const allIds = [loc.id, ...descendantIds];
-          const memories = await getMemoriesByLocationTree(allIds);
+          const [memories, books] = await Promise.all([
+            getMemoriesByLocationTree(allIds),
+            getBooksByLocationIds(allIds),
+          ]);
           setAllMemories(memories);
+          setLocationBooks(books);
         }
       })
       .catch(console.error)
@@ -157,19 +178,24 @@ export function LocationMemoryScreen() {
     [allLocations, location]
   );
 
-  // Count all tree memories per child (for the chips)
+  const allItems = useMemo<DisplayItem[]>(() => {
+    const bookItems = locationBooks.map(bookToDisplayItem);
+    return [...allMemories, ...bookItems].sort((a, b) => b.date.localeCompare(a.date));
+  }, [allMemories, locationBooks]);
+
+  // Count all tree items per child (for the chips)
   const childMemoryCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     for (const child of children) {
       const childDescendantIds = getDescendantIds(allLocations, child.id);
       const childIds = new Set([child.id, ...childDescendantIds]);
-      counts[child.id] = allMemories.filter((m) => childIds.has(m.location_id)).length;
+      counts[child.id] = allItems.filter((m) => childIds.has(m.location_id)).length;
     }
     return counts;
-  }, [children, allLocations, allMemories]);
+  }, [children, allLocations, allItems]);
 
   const filteredMemories = useMemo(() => {
-    let result = allMemories;
+    let result = allItems;
 
     // Sub-location filter
     if (subFilter !== 'all') {
@@ -184,7 +210,7 @@ export function LocationMemoryScreen() {
     }
 
     return result;
-  }, [allMemories, subFilter, typeFilter, allLocations]);
+  }, [allItems, subFilter, typeFilter, allLocations]);
 
   const showLocationBadge = subFilter === 'all' && children.length > 0;
 
@@ -262,7 +288,7 @@ export function LocationMemoryScreen() {
         )}
 
         {/* Filter bar */}
-        {allMemories.length > 0 && (
+        {allItems.length > 0 && (
           <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.35, duration: 0.6 }} className="flex items-center gap-6 mb-6 flex-wrap">
             {/* Type filter */}
             <div className="flex items-center gap-4">
@@ -301,7 +327,7 @@ export function LocationMemoryScreen() {
         ) : (
           <div style={{ columns: '3 160px', columnGap: '16px' }}>
             {filteredMemories.map((memory, index) => (
-              <MemoryCard key={memory.id} memory={memory} index={index} showLocation={showLocationBadge} />
+              <MemoryCard key={memory.id} memory={memory} index={index} showLocation={showLocationBadge} to={(memory as DisplayItem)._to} />
             ))}
           </div>
         )}

--- a/src/app/components/LocationPickerSheet.tsx
+++ b/src/app/components/LocationPickerSheet.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { X } from 'lucide-react';
+import { getLocations } from '../../lib/locationService';
+import type { Location } from '../../lib/types';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (location: Location) => void;
+  currentLocationId?: string | null;
+}
+
+export function LocationPickerSheet({ open, onClose, onSelect, currentLocationId }: Props) {
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setQuery('');
+    getLocations().then(setLocations).catch(console.error).finally(() => setLoading(false));
+  }, [open]);
+
+  const filtered = query.trim()
+    ? locations.filter((l) => l.name.toLowerCase().includes(query.toLowerCase()))
+    : locations;
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+            style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.3)', zIndex: 200 }}
+          />
+          <motion.div
+            initial={{ y: '100%' }}
+            animate={{ y: 0 }}
+            exit={{ y: '100%' }}
+            transition={{ type: 'spring', damping: 28, stiffness: 300 }}
+            style={{
+              position: 'fixed', bottom: 0, left: 0, right: 0,
+              background: 'var(--paper-bg)',
+              borderTop: '1px solid var(--ink-faint)',
+              zIndex: 201,
+              maxHeight: '70vh',
+              display: 'flex',
+              flexDirection: 'column',
+              fontFamily: 'var(--font-serif)',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 20px 12px', borderBottom: '1px solid var(--ink-faint)' }}>
+              <span style={{ color: 'var(--ink-text)', fontSize: '0.9rem' }}>选择地点</span>
+              <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--ink-faint)', padding: 0 }}>
+                <X size={18} />
+              </button>
+            </div>
+
+            <div style={{ padding: '12px 20px', borderBottom: '1px solid var(--ink-faint)' }}>
+              <input
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="搜索地点…"
+                autoFocus
+                style={{
+                  width: '100%', padding: '8px 0', background: 'transparent',
+                  border: 'none', borderBottom: '1px solid var(--ink-faint)',
+                  color: 'var(--ink-text)', fontSize: '0.85rem',
+                  fontFamily: 'var(--font-serif)', outline: 'none',
+                }}
+              />
+            </div>
+
+            <div style={{ overflowY: 'auto', flex: 1 }}>
+              {loading ? (
+                <div style={{ padding: '20px', textAlign: 'center', color: 'var(--ink-faint)', fontSize: '0.8rem' }}>…</div>
+              ) : filtered.length === 0 ? (
+                <div style={{ padding: '20px', textAlign: 'center', color: 'var(--ink-faint)', fontSize: '0.8rem' }}>暂无地点</div>
+              ) : (
+                filtered.map((loc) => (
+                  <button
+                    key={loc.id}
+                    onClick={() => { onSelect(loc); onClose(); }}
+                    style={{
+                      display: 'block', width: '100%', padding: '14px 20px',
+                      background: loc.id === currentLocationId ? 'var(--paper-warm)' : 'transparent',
+                      border: 'none', borderBottom: '1px solid var(--ink-faint)',
+                      textAlign: 'left', cursor: 'pointer',
+                      color: 'var(--ink-text)', fontSize: '0.875rem',
+                      fontFamily: 'var(--font-serif)',
+                    }}
+                    className="hover:opacity-70 transition-opacity"
+                  >
+                    {loc.name}
+                  </button>
+                ))
+              )}
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/app/components/MemoryDetailScreen.tsx
+++ b/src/app/components/MemoryDetailScreen.tsx
@@ -3,61 +3,88 @@ import { useParams, Link, useNavigate } from 'react-router';
 import { motion } from 'motion/react';
 import { ArrowLeft, ChevronLeft, ChevronRight } from 'lucide-react';
 import { getMemoryById, deleteMemory } from '../../lib/memoryService';
-import type { Memory } from '../../lib/types';
+import type { Memory, PhotoImage } from '../../lib/types';
 
-function ImageGallery({ urls, border }: { urls: string[]; border?: string }) {
+function ImageGallery({ items }: { items: Pick<PhotoImage, 'image_url' | 'video_url' | 'media_type'>[] }) {
   const [index, setIndex] = useState(0);
   const [zoomed, setZoomed] = useState(false);
+  const [playingVideo, setPlayingVideo] = useState(false);
 
-  if (urls.length === 0) return null;
+  if (items.length === 0) return null;
+
+  const current = items[index];
+  const isVideo = current.media_type === 'video' && !!current.video_url;
+
+  function handleNext(e: React.MouseEvent) {
+    e.stopPropagation();
+    setPlayingVideo(false);
+    setIndex((i) => (i + 1) % items.length);
+  }
+
+  function handlePrev(e: React.MouseEvent) {
+    e.stopPropagation();
+    setPlayingVideo(false);
+    setIndex((i) => (i - 1 + items.length) % items.length);
+  }
 
   return (
     <div>
       <div style={{ position: 'relative' }}>
         <div
-          className="overflow-hidden cursor-zoom-in"
           style={{
-            boxShadow: '0 4px 16px var(--paper-shadow)',
-            border: border ?? 'none',
             transform: zoomed ? 'scale(1.5)' : 'scale(1)',
             transition: 'transform 0.4s ease',
+            cursor: isVideo ? 'default' : 'zoom-in',
+            overflow: 'hidden',
           }}
-          onClick={() => setZoomed(!zoomed)}
+          onClick={() => { if (!isVideo) setZoomed((z) => !z); }}
         >
-          <img
-            src={urls[index]}
-            alt=""
-            className="w-full"
-            style={{ display: 'block', filter: 'contrast(0.92) saturate(0.85)' }}
-          />
+          {isVideo && playingVideo ? (
+            <video
+              src={current.video_url!}
+              className="w-full"
+              style={{ display: 'block' }}
+              controls
+              autoPlay
+            />
+          ) : (
+            <div style={{ position: 'relative' }}>
+              <img
+                src={current.image_url}
+                alt=""
+                className="w-full"
+                style={{ display: 'block', filter: 'contrast(0.92) saturate(0.85)' }}
+              />
+              {isVideo && !playingVideo && (
+                <div
+                  style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
+                  onClick={(e) => { e.stopPropagation(); setPlayingVideo(true); }}
+                >
+                  <div style={{ width: '56px', height: '56px', borderRadius: '50%', background: 'rgba(58,54,50,0.55)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <svg width="20" height="24" viewBox="0 0 10 12" fill="white"><polygon points="0,0 10,6 0,12"/></svg>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
-        {urls.length > 1 && !zoomed && (
+        {items.length > 1 && !zoomed && (
           <>
-            <button
-              onClick={(e) => { e.stopPropagation(); setIndex((i) => (i - 1 + urls.length) % urls.length); }}
-              style={{ position: 'absolute', left: '8px', top: '50%', transform: 'translateY(-50%)', background: 'rgba(58,54,50,0.45)', border: 'none', borderRadius: '50%', width: '32px', height: '32px', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 0 }}
-            >
+            <button onClick={handlePrev} style={{ position: 'absolute', left: '8px', top: '50%', transform: 'translateY(-50%)', background: 'rgba(58,54,50,0.45)', border: 'none', borderRadius: '50%', width: '32px', height: '32px', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 0 }}>
               <ChevronLeft size={16} color="white" />
             </button>
-            <button
-              onClick={(e) => { e.stopPropagation(); setIndex((i) => (i + 1) % urls.length); }}
-              style={{ position: 'absolute', right: '8px', top: '50%', transform: 'translateY(-50%)', background: 'rgba(58,54,50,0.45)', border: 'none', borderRadius: '50%', width: '32px', height: '32px', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 0 }}
-            >
+            <button onClick={handleNext} style={{ position: 'absolute', right: '8px', top: '50%', transform: 'translateY(-50%)', background: 'rgba(58,54,50,0.45)', border: 'none', borderRadius: '50%', width: '32px', height: '32px', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 0 }}>
               <ChevronRight size={16} color="white" />
             </button>
           </>
         )}
       </div>
 
-      {urls.length > 1 && (
+      {items.length > 1 && (
         <div style={{ display: 'flex', justifyContent: 'center', gap: '6px', marginTop: '10px' }}>
-          {urls.map((_, i) => (
-            <button
-              key={i}
-              onClick={() => setIndex(i)}
-              style={{ width: '6px', height: '6px', borderRadius: '50%', border: 'none', cursor: 'pointer', padding: 0, background: i === index ? 'var(--ink-light)' : 'var(--ink-faint)', opacity: i === index ? 1 : 0.4 }}
-            />
+          {items.map((_, i) => (
+            <button key={i} onClick={() => { setIndex(i); setPlayingVideo(false); }} style={{ width: '6px', height: '6px', borderRadius: '50%', border: 'none', cursor: 'pointer', padding: 0, background: i === index ? 'var(--ink-light)' : 'var(--ink-faint)', opacity: i === index ? 1 : 0.4 }} />
           ))}
         </div>
       )}
@@ -195,16 +222,18 @@ export function MemoryDetailScreen() {
     }
   }
 
+  const isPhoto = memory.type === 'photo';
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.8 }}
-      className="min-h-screen p-6 flex flex-col"
+      className="min-h-screen flex flex-col"
       style={{ fontFamily: 'var(--font-serif)' }}
     >
       {/* Header */}
-      <div className="max-w-3xl mx-auto w-full mb-8 flex items-center justify-between">
+      <div className="max-w-3xl mx-auto w-full flex items-center justify-between" style={{ padding: '24px 24px 0' }}>
         <Link
           to={`/location/${memory.location_id}`}
           style={{ color: 'var(--ink-light)', fontSize: '0.875rem' }}
@@ -233,17 +262,17 @@ export function MemoryDetailScreen() {
       </div>
 
       {/* Content */}
-      <div className="flex-1 flex items-center justify-center">
+      <div className="flex-1 flex items-center justify-center" style={{ padding: '24px 12px' }}>
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.3, duration: 0.8 }}
           className="w-full"
-          style={{ maxWidth: memory.type === 'note' && memory.note?.note_type === 'handwritten' ? '900px' : '576px' }}
+          style={{ maxWidth: memory.type === 'note' && memory.note?.note_type === 'handwritten' ? '900px' : isPhoto ? '800px' : '576px' }}
         >
           {/* Photo */}
           {memory.type === 'photo' && memory.photo && (
-            <ImageGallery urls={memory.photo.images.map((i) => i.image_url)} />
+            <ImageGallery items={memory.photo.images} />
           )}
 
           {/* Note: handwritten */}
@@ -301,7 +330,8 @@ export function MemoryDetailScreen() {
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 0.6, duration: 0.8 }}
-        className="max-w-3xl mx-auto w-full mt-8 text-center"
+        className="max-w-3xl mx-auto w-full text-center"
+        style={{ padding: '0 12px 32px' }}
       >
         {memory.type === 'photo' && memory.photo?.caption && (
           <p style={{ color: 'var(--ink-text)', fontSize: '0.9rem', marginBottom: '8px' }}>{memory.photo.caption}</p>

--- a/src/lib/bookService.ts
+++ b/src/lib/bookService.ts
@@ -11,7 +11,7 @@ export interface BookData {
   readDate?: string | null
 }
 
-const BOOK_SELECT = `*, quotes:book_quotes(*), memory_books(memory:memories(date))`
+const BOOK_SELECT = `*, quotes:book_quotes(*), memory_books(memory:memories(date)), location:locations(*)`
 
 export async function getAllBooks(): Promise<Book[]> {
   const { data, error } = await supabase
@@ -150,10 +150,26 @@ function yearOf(dateStr: string): number {
   return parseInt(dateStr.slice(0, 4), 10)
 }
 
+export async function updateBookLocation(bookId: string, locationId: string | null): Promise<void> {
+  const { error } = await supabase.from('books').update({ location_id: locationId }).eq('id', bookId)
+  if (error) throw error
+}
+
+export async function getBooksByLocationIds(locationIds: string[]): Promise<Book[]> {
+  if (locationIds.length === 0) return []
+  const { data, error } = await supabase
+    .from('books')
+    .select(BOOK_SELECT)
+    .in('location_id', locationIds)
+  if (error) throw error
+  return (data as any[]).map(normalizeBook) as Book[]
+}
+
 function normalizeBook(raw: any): Book {
   const quotes = Array.isArray(raw.quotes) ? raw.quotes.sort((a: any, b: any) => a.order - b.order) : []
   const memoryDates = Array.isArray(raw.memory_books)
     ? raw.memory_books.map((mb: any) => mb.memory?.date).filter(Boolean) as string[]
     : []
-  return { ...raw, quotes, memoryDates, memory_books: undefined }
+  const location = raw.location ?? undefined
+  return { ...raw, quotes, memoryDates, location, memory_books: undefined }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,7 +22,9 @@ export interface Memory {
 export interface PhotoImage {
   id: string
   memory_id: string
-  image_url: string
+  image_url: string   // thumbnail for videos, full image for photos
+  video_url: string | null
+  media_type: 'image' | 'video'
   order: number
 }
 
@@ -54,6 +56,8 @@ export interface Book {
   reading_notes: string | null
   read_date: string | null
   created_at: string
+  location_id: string | null
+  location?: Location
   quotes: BookQuote[]
   memoryDates?: string[] // linked memory dates, used for year filtering
 }


### PR DESCRIPTION
## Summary

- Books can now be associated with a saved location directly (`location_id` column on `books` table)
- **BookDetailScreen**: shows location with tap-to-navigate, change, and remove buttons; falls back to linked memory location if no direct location set; shows "+ 添加阅读地点" when none
- **LocationMemoryScreen**: queries books by `location_id` and merges them into the memory grid alongside photos/notes
- **LocationPickerSheet**: new bottom sheet component for picking from saved locations
- **MemoryDetailScreen**: photo/video frame enlarged (max-width 800px, side padding reduced to 12px for a more immersive feel)

## Migration required

Run in Supabase SQL Editor before deploying:
\`\`\`sql
ALTER TABLE books
  ADD COLUMN location_id UUID REFERENCES locations(id) ON DELETE SET NULL;
\`\`\`

## Test plan

- [ ] Open a book detail, tap "+ 添加阅读地点", pick a location — verify it appears and is clickable
- [ ] Tap "更改" to switch location, "移除" to clear it
- [ ] Visit the location page — verify the book appears in the grid
- [ ] Book with no direct location but linked memory — verify fallback location name shows (read-only)
- [ ] Photo memory detail — verify image is larger and has less side padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)