### PR TITLE
feat: Goodreads 自动同步 — RSS + Claude 地点识别批量导入

### DIFF
--- a/src/app/components/BookshelfScreen.tsx
+++ b/src/app/components/BookshelfScreen.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
-import { motion } from 'motion/react';
+import { motion, AnimatePresence } from 'motion/react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { getAllBooks, getAvailableYears, getBooksForYear } from '../../lib/bookService';
 import type { Book } from '../../lib/types';
+import { GoodreadsSyncSheet } from './GoodreadsSyncSheet';
 
 const SPINE_COLORS = [
   '#3d5a47', '#8b4a2b', '#2c3e5a', '#5c4033',
@@ -129,8 +130,9 @@ export function BookshelfScreen() {
   const [availableYears, setAvailableYears] = useState<number[]>([]);
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
   const [loading, setLoading] = useState(true);
+  const [showSync, setShowSync] = useState(false);
 
-  useEffect(() => {
+  function loadBooks() {
     getAllBooks().then((books) => {
       setAllBooks(books);
       const years = getAvailableYears(books);
@@ -140,12 +142,34 @@ export function BookshelfScreen() {
         setSelectedYear(years.includes(currentYear) ? currentYear : years[0]);
       }
     }).catch(console.error).finally(() => setLoading(false));
-  }, []);
+  }
+
+  useEffect(() => { loadBooks(); }, []);
 
   const booksThisYear = getBooksForYear(allBooks, selectedYear);
 
   return (
     <div style={{ fontFamily: 'var(--font-serif)', minHeight: '60vh', paddingBottom: '4rem' }}>
+      {/* Sync button */}
+      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '0 24px 8px' }}>
+        <button
+          onClick={() => setShowSync(true)}
+          className="glass-chip"
+          style={{ fontSize: '0.75rem', padding: '5px 12px' }}
+        >
+          同步 Goodreads
+        </button>
+      </div>
+
+      <AnimatePresence>
+        {showSync && (
+          <GoodreadsSyncSheet
+            onClose={() => setShowSync(false)}
+            onDone={() => { setShowSync(false); loadBooks(); }}
+          />
+        )}
+      </AnimatePresence>
+
       {loading ? (
         <div className="flex items-center justify-center" style={{ height: '40vh', color: 'var(--ink-faint)', fontSize: '0.875rem' }}>
           …

--- a/src/app/components/GoodreadsSyncSheet.tsx
+++ b/src/app/components/GoodreadsSyncSheet.tsx
@@ -1,0 +1,320 @@
+import { useEffect, useRef, useState } from 'react';
+import { X, SkipForward } from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
+import {
+  fetchGoodreadsPreview,
+  importBooks,
+  getStoredGoodreadsUserId,
+  setStoredGoodreadsUserId,
+} from '../../lib/goodreadsSyncService';
+import type { SyncPreviewItem } from '../../lib/goodreadsSyncService';
+import { getLocations } from '../../lib/locationService';
+import type { Location } from '../../lib/types';
+
+type Status = 'idle' | 'loading' | 'preview' | 'importing' | 'done' | 'error'
+
+const labelStyle: React.CSSProperties = {
+  color: 'var(--ink-light)', fontSize: '0.7rem', display: 'block',
+  marginBottom: '4px', letterSpacing: '0.05em',
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%', padding: '10px 0', background: 'transparent', border: 'none',
+  borderBottom: '1px solid var(--ink-faint)', color: 'var(--ink-text)',
+  fontSize: '0.9rem', fontFamily: 'var(--font-serif)', outline: 'none',
+}
+
+export function GoodreadsSyncSheet({ onClose, onDone }: { onClose: () => void; onDone: () => void }) {
+  const [status, setStatus] = useState<Status>('idle')
+  const [userId, setUserId] = useState(getStoredGoodreadsUserId() ?? '')
+  const [items, setItems] = useState<SyncPreviewItem[]>([])
+  const [locations, setLocations] = useState<Location[]>([])
+  const [result, setResult] = useState<{ booksImported: number; locationsCreated: number } | null>(null)
+  const [errorMsg, setErrorMsg] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    getLocations().then(setLocations).catch(console.error)
+    // Auto-start if we already have a user ID
+    if (getStoredGoodreadsUserId()) handleSync(getStoredGoodreadsUserId()!)
+    else setTimeout(() => inputRef.current?.focus(), 100)
+  }, [])
+
+  async function handleSync(id: string) {
+    if (!id.trim()) return
+    setStoredGoodreadsUserId(id.trim())
+    setStatus('loading')
+    setErrorMsg('')
+    try {
+      const books = await fetchGoodreadsPreview(id.trim())
+      if (books.length === 0) {
+        setStatus('done')
+        setResult({ booksImported: 0, locationsCreated: 0 })
+        return
+      }
+      setItems(books.map((b) => ({ ...b, skipped: false })))
+      setStatus('preview')
+    } catch (err: any) {
+      setErrorMsg(err?.message ?? String(err))
+      setStatus('error')
+    }
+  }
+
+  async function handleImport() {
+    setStatus('importing')
+    try {
+      const res = await importBooks(items, locations)
+      setResult(res)
+      setStatus('done')
+      onDone()
+    } catch (err: any) {
+      setErrorMsg(err?.message ?? String(err))
+      setStatus('error')
+    }
+  }
+
+  function toggleSkip(idx: number) {
+    setItems((prev) => prev.map((item, i) => i === idx ? { ...item, skipped: !item.skipped } : item))
+  }
+
+  function setOverride(idx: number, locationId: string | null) {
+    setItems((prev) => prev.map((item, i) =>
+      i === idx ? { ...item, overrideLocationId: locationId === '__keep__' ? undefined : locationId } : item
+    ))
+  }
+
+  const activeCount = items.filter((i) => !i.skipped).length
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.55)', zIndex: 200, display: 'flex', alignItems: 'flex-end' }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <motion.div
+        initial={{ y: '100%' }}
+        animate={{ y: 0 }}
+        exit={{ y: '100%' }}
+        transition={{ type: 'spring', damping: 30, stiffness: 300 }}
+        style={{
+          width: '100%', maxWidth: '640px', margin: '0 auto',
+          background: 'rgba(22,20,18,0.97)', backdropFilter: 'blur(24px)',
+          borderRadius: '20px 20px 0 0', border: '1px solid rgba(255,255,255,0.08)',
+          maxHeight: '90vh', display: 'flex', flexDirection: 'column',
+          fontFamily: 'var(--font-serif)',
+        }}
+      >
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '20px 24px 16px' }}>
+          <h3 style={{ color: 'var(--ink-text)', fontSize: '1rem', fontWeight: 400, margin: 0 }}>
+            同步 Goodreads
+          </h3>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--ink-faint)', padding: 0 }}>
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '0 24px 24px' }}>
+
+          {/* Idle — user ID input */}
+          {status === 'idle' && (
+            <div>
+              <p style={{ color: 'var(--ink-light)', fontSize: '0.8rem', marginBottom: '20px', lineHeight: 1.7 }}>
+                在 Goodreads 个人主页 URL 里找到你的用户 ID（数字），例如：
+                <br />
+                <span style={{ color: 'var(--ink-faint)', fontSize: '0.75rem' }}>goodreads.com/user/show/<strong style={{ color: 'var(--ink-light)' }}>12345678</strong></span>
+              </p>
+              <label style={labelStyle}>Goodreads User ID</label>
+              <input
+                ref={inputRef}
+                type="text"
+                value={userId}
+                onChange={(e) => setUserId(e.target.value)}
+                placeholder="12345678"
+                style={inputStyle}
+                onKeyDown={(e) => e.key === 'Enter' && handleSync(userId)}
+              />
+              <div style={{ marginTop: '24px' }}>
+                <button
+                  onClick={() => handleSync(userId)}
+                  disabled={!userId.trim()}
+                  className="glass-action-btn"
+                  style={{ opacity: userId.trim() ? 1 : 0.4 }}
+                >
+                  开始同步
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Loading */}
+          {status === 'loading' && (
+            <div style={{ textAlign: 'center', padding: '3rem 0', color: 'var(--ink-faint)', fontSize: '0.875rem' }}>
+              正在拉取 Goodreads 书单并识别地点…
+            </div>
+          )}
+
+          {/* Preview */}
+          {status === 'preview' && (
+            <div>
+              <p style={{ color: 'var(--ink-light)', fontSize: '0.8rem', marginBottom: '16px' }}>
+                检测到 <strong style={{ color: 'var(--ink-text)' }}>{activeCount}</strong> 本新书。确认后导入。
+              </p>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', marginBottom: '24px' }}>
+                {items.map((item, idx) => (
+                  <PreviewRow
+                    key={item.goodreads_id}
+                    item={item}
+                    locations={locations}
+                    onSkip={() => toggleSkip(idx)}
+                    onOverride={(id) => setOverride(idx, id)}
+                  />
+                ))}
+              </div>
+              <button
+                onClick={handleImport}
+                disabled={activeCount === 0}
+                className="glass-action-btn"
+                style={{ opacity: activeCount > 0 ? 1 : 0.4 }}
+              >
+                导入 {activeCount} 本书
+              </button>
+            </div>
+          )}
+
+          {/* Importing */}
+          {status === 'importing' && (
+            <div style={{ textAlign: 'center', padding: '3rem 0', color: 'var(--ink-faint)', fontSize: '0.875rem' }}>
+              导入中…
+            </div>
+          )}
+
+          {/* Done */}
+          {status === 'done' && (
+            <div style={{ textAlign: 'center', padding: '2rem 0' }}>
+              <p style={{ color: 'var(--ink-text)', fontSize: '1rem', marginBottom: '8px' }}>
+                {result?.booksImported === 0
+                  ? '已是最新，没有新书'
+                  : `已导入 ${result?.booksImported} 本书`}
+              </p>
+              {(result?.locationsCreated ?? 0) > 0 && (
+                <p style={{ color: 'var(--ink-light)', fontSize: '0.8rem' }}>
+                  新建了 {result?.locationsCreated} 个地点
+                </p>
+              )}
+              <button onClick={onClose} className="glass-action-btn" style={{ marginTop: '24px' }}>
+                关闭
+              </button>
+            </div>
+          )}
+
+          {/* Error */}
+          {status === 'error' && (
+            <div style={{ padding: '1rem 0' }}>
+              <p style={{ color: 'var(--ink-light)', fontSize: '0.85rem', marginBottom: '16px' }}>{errorMsg}</p>
+              <button onClick={() => setStatus('idle')} className="glass-action-btn">重试</button>
+            </div>
+          )}
+        </div>
+      </motion.div>
+    </motion.div>
+  )
+}
+
+function PreviewRow({
+  item,
+  locations,
+  onSkip,
+  onOverride,
+}: {
+  item: SyncPreviewItem
+  locations: Location[]
+  onSkip: () => void
+  onOverride: (id: string | null) => void
+}) {
+  const detected = item.detectedLocation
+  const effectiveLocationValue =
+    item.overrideLocationId !== undefined
+      ? (item.overrideLocationId ?? '')
+      : detected
+        ? (detected.isNew ? `__new__${detected.name}` : (detected.existingId ?? ''))
+        : ''
+
+  function handleSelect(val: string) {
+    if (val === '__keep__') { onOverride('__keep__' as any); return }
+    if (val === '') { onOverride(null); return }
+    if (val.startsWith('__new__')) return // can't "select" the new-location pseudo-option
+    onOverride(val)
+  }
+
+  return (
+    <div style={{
+      display: 'flex', gap: '12px', alignItems: 'flex-start',
+      padding: '12px', borderRadius: '10px',
+      background: item.skipped ? 'rgba(255,255,255,0.02)' : 'rgba(255,255,255,0.05)',
+      opacity: item.skipped ? 0.4 : 1,
+      border: '1px solid rgba(255,255,255,0.06)',
+    }}>
+      {/* Cover */}
+      {item.cover_url ? (
+        <img src={item.cover_url} alt="" style={{ width: '40px', height: '56px', objectFit: 'cover', flexShrink: 0, borderRadius: '3px' }} loading="lazy" />
+      ) : (
+        <div style={{ width: '40px', height: '56px', flexShrink: 0, background: 'rgba(255,255,255,0.06)', borderRadius: '3px' }} />
+      )}
+
+      {/* Info */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ color: 'var(--ink-text)', fontSize: '0.85rem', marginBottom: '2px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {item.title}
+        </div>
+        <div style={{ color: 'var(--ink-light)', fontSize: '0.75rem', marginBottom: '8px' }}>
+          {item.author} · {item.date_read}
+        </div>
+
+        {/* Location selector */}
+        <select
+          value={effectiveLocationValue}
+          onChange={(e) => handleSelect(e.target.value)}
+          disabled={item.skipped}
+          style={{
+            background: 'transparent', border: '1px solid rgba(255,255,255,0.1)',
+            borderRadius: '6px', padding: '4px 8px', color: 'var(--ink-text)',
+            fontSize: '0.75rem', fontFamily: 'var(--font-serif)', cursor: 'pointer',
+            maxWidth: '100%',
+          }}
+        >
+          <option value="">无地点</option>
+          {detected?.isNew && (
+            <option value={`__new__${detected.name}`} disabled>
+              ★ 新建：{detected.name}（{detected.lat.toFixed(2)}°, {detected.lng.toFixed(2)}°）
+            </option>
+          )}
+          {detected?.isNew && (
+            <option value="" style={{ color: 'var(--ink-faint)' }}>↑ 使用上方新建地点</option>
+          )}
+          {locations.map((l) => (
+            <option key={l.id} value={l.id}>{l.name}</option>
+          ))}
+        </select>
+
+        {detected?.isNew && item.overrideLocationId === undefined && (
+          <div style={{ color: 'rgba(140,200,140,0.7)', fontSize: '0.65rem', marginTop: '4px' }}>
+            将新建地点「{detected.name}」（{detected.lat.toFixed(2)}°N, {detected.lng.toFixed(2)}°E）
+          </div>
+        )}
+      </div>
+
+      {/* Skip button */}
+      <button
+        onClick={onSkip}
+        title={item.skipped ? '取消跳过' : '跳过这本'}
+        style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--ink-faint)', padding: '4px', flexShrink: 0, marginTop: '2px' }}
+      >
+        <SkipForward size={14} />
+      </button>
+    </div>
+  )
+}

--- a/src/lib/bookService.ts
+++ b/src/lib/bookService.ts
@@ -150,6 +150,15 @@ function yearOf(dateStr: string): number {
   return parseInt(dateStr.slice(0, 4), 10)
 }
 
+export async function getExistingGoodreadsIds(): Promise<Set<string>> {
+  const { data, error } = await supabase
+    .from('books')
+    .select('goodreads_id')
+    .not('goodreads_id', 'is', null)
+  if (error) throw error
+  return new Set((data as { goodreads_id: string }[]).map((r) => r.goodreads_id))
+}
+
 export async function updateBookLocation(bookId: string, locationId: string | null): Promise<void> {
   const { error } = await supabase.from('books').update({ location_id: locationId }).eq('id', bookId)
   if (error) throw error

--- a/src/lib/goodreadsRssParser.test.ts
+++ b/src/lib/goodreadsRssParser.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import { parseGoodreadsRss, filterNewBooks, normalizeDate } from './goodreadsRssParser'
+
+const makeItem = (fields: Record<string, string>) => {
+  const entries = Object.entries(fields)
+    .map(([k, v]) => `<${k}><![CDATA[${v}]]></${k}>`)
+    .join('\n')
+  return `<item>\n${entries}\n</item>`
+}
+
+const makeRss = (items: string[]) =>
+  `<rss><channel>${items.join('')}</channel></rss>`
+
+describe('parseGoodreadsRss', () => {
+  it('parses basic fields correctly', () => {
+    const xml = makeRss([
+      makeItem({
+        book_id: '12345',
+        title: 'The Kite Runner',
+        author_name: 'Khaled Hosseini',
+        book_image_url: 'https://example.com/cover.jpg',
+        user_date_read: 'Jan 15, 2024',
+        user_review: '<p>Great book</p>',
+        book_description: 'A story set in Kabul.',
+      }),
+    ])
+
+    const books = parseGoodreadsRss(xml)
+    expect(books).toHaveLength(1)
+    expect(books[0].goodreads_id).toBe('12345')
+    expect(books[0].title).toBe('The Kite Runner')
+    expect(books[0].author).toBe('Khaled Hosseini')
+    expect(books[0].cover_url).toBe('https://example.com/cover.jpg')
+    expect(books[0].date_read).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(books[0].reading_notes).toBe('Great book')
+    expect(books[0].description).toBe('A story set in Kabul.')
+  })
+
+  it('defaults date_read to today when missing', () => {
+    const today = new Date().toISOString().slice(0, 10)
+    const xml = makeRss([
+      makeItem({ book_id: '1', title: 'No Date Book', author_name: 'Author' }),
+    ])
+    expect(parseGoodreadsRss(xml)[0].date_read).toBe(today)
+  })
+
+  it('sets reading_notes to null when review is empty', () => {
+    const xml = makeRss([
+      makeItem({ book_id: '2', title: 'Silent Book', author_name: 'Author', user_review: '' }),
+    ])
+    expect(parseGoodreadsRss(xml)[0].reading_notes).toBeNull()
+  })
+
+  it('strips HTML tags from reading_notes', () => {
+    const xml = makeRss([
+      makeItem({ book_id: '3', title: 'Tagged', author_name: 'Author', user_review: '<b>Bold</b> review' }),
+    ])
+    expect(parseGoodreadsRss(xml)[0].reading_notes).toBe('Bold review')
+  })
+
+  it('returns empty array for empty RSS', () => {
+    expect(parseGoodreadsRss('<rss><channel></channel></rss>')).toHaveLength(0)
+  })
+
+  it('skips items without book_id or title', () => {
+    const xml = makeRss([
+      makeItem({ author_name: 'Nobody' }),
+      makeItem({ book_id: '99', title: 'Valid Book', author_name: 'Author' }),
+    ])
+    const books = parseGoodreadsRss(xml)
+    expect(books).toHaveLength(1)
+    expect(books[0].goodreads_id).toBe('99')
+  })
+
+  it('parses multiple books', () => {
+    const xml = makeRss([
+      makeItem({ book_id: '1', title: 'Book One', author_name: 'Author A' }),
+      makeItem({ book_id: '2', title: 'Book Two', author_name: 'Author B' }),
+      makeItem({ book_id: '3', title: 'Book Three', author_name: 'Author C' }),
+    ])
+    expect(parseGoodreadsRss(xml)).toHaveLength(3)
+  })
+
+  it('decodes HTML entities in title and author', () => {
+    const xml = makeRss([
+      makeItem({ book_id: '5', title: 'Catch &amp; Release', author_name: 'O&#39;Brien' }),
+    ])
+    const books = parseGoodreadsRss(xml)
+    expect(books[0].title).toBe('Catch & Release')
+    expect(books[0].author).toBe("O'Brien")
+  })
+})
+
+describe('filterNewBooks', () => {
+  const books = [
+    { goodreads_id: 'a', title: 'A', author: '', cover_url: '', date_read: '2024-01-01', reading_notes: null, description: '' },
+    { goodreads_id: 'b', title: 'B', author: '', cover_url: '', date_read: '2024-01-01', reading_notes: null, description: '' },
+    { goodreads_id: 'c', title: 'C', author: '', cover_url: '', date_read: '2024-01-01', reading_notes: null, description: '' },
+  ]
+
+  it('filters out books with existing goodreads_ids', () => {
+    const result = filterNewBooks(books, new Set(['a', 'c']))
+    expect(result).toHaveLength(1)
+    expect(result[0].goodreads_id).toBe('b')
+  })
+
+  it('returns all books when no existing ids', () => {
+    expect(filterNewBooks(books, new Set())).toHaveLength(3)
+  })
+
+  it('returns empty when all already imported', () => {
+    expect(filterNewBooks(books, new Set(['a', 'b', 'c']))).toHaveLength(0)
+  })
+})
+
+describe('normalizeDate', () => {
+  it('returns today for null input', () => {
+    const today = new Date().toISOString().slice(0, 10)
+    expect(normalizeDate(null)).toBe(today)
+  })
+
+  it('parses "Jan 15, 2024" format', () => {
+    expect(normalizeDate('Jan 15, 2024')).toBe('2024-01-15')
+  })
+
+  it('returns today for unparseable input', () => {
+    const today = new Date().toISOString().slice(0, 10)
+    expect(normalizeDate('not-a-date')).toBe(today)
+  })
+})

--- a/src/lib/goodreadsRssParser.ts
+++ b/src/lib/goodreadsRssParser.ts
@@ -1,0 +1,86 @@
+export interface RawGoodreadsBook {
+  goodreads_id: string
+  title: string
+  author: string
+  cover_url: string
+  date_read: string       // YYYY-MM-DD, defaults to today if missing
+  reading_notes: string | null
+  description: string
+}
+
+export function parseGoodreadsRss(xml: string): RawGoodreadsBook[] {
+  const items = xml.match(/<item>([\s\S]*?)<\/item>/g) ?? []
+  return items.map(parseItem).filter((b): b is RawGoodreadsBook => b !== null)
+}
+
+export function filterNewBooks(
+  books: RawGoodreadsBook[],
+  existingIds: Set<string>
+): RawGoodreadsBook[] {
+  return books.filter((b) => !existingIds.has(b.goodreads_id))
+}
+
+function parseItem(item: string): RawGoodreadsBook | null {
+  const goodreads_id = extractTag(item, 'book_id') ?? extractAttr(item, 'guid')
+  const title = decodeEntities(extractTag(item, 'title') ?? '')
+  const author = decodeEntities(extractTag(item, 'author_name') ?? '')
+  const cover_url = extractTag(item, 'book_image_url') ?? extractTag(item, 'image_url') ?? ''
+  const date_read = extractTag(item, 'user_date_read') ?? null
+  const reading_notes = cleanHtml(extractTag(item, 'user_review') ?? '') || null
+  const description = cleanHtml(
+    extractCdata(item, 'book_description') ?? extractTag(item, 'description') ?? ''
+  )
+
+  if (!goodreads_id || !title) return null
+
+  return {
+    goodreads_id,
+    title,
+    author,
+    cover_url,
+    date_read: normalizeDate(date_read),
+    reading_notes,
+    description,
+  }
+}
+
+function extractTag(xml: string, tag: string): string | null {
+  const m =
+    xml.match(new RegExp(`<${tag}[^>]*><!\\[CDATA\\[([\\s\\S]*?)\\]\\]><\\/${tag}>`, 'i')) ??
+    xml.match(new RegExp(`<${tag}[^>]*>([^<]*)<\\/${tag}>`, 'i'))
+  return m?.[1]?.trim() ?? null
+}
+
+function extractCdata(xml: string, tag: string): string | null {
+  const m = xml.match(new RegExp(`<${tag}[^>]*><!\\[CDATA\\[([\\s\\S]*?)\\]\\]><\\/${tag}>`, 'i'))
+  return m?.[1]?.trim() ?? null
+}
+
+function extractAttr(xml: string, attr: string): string | null {
+  const m = xml.match(new RegExp(`${attr}="([^"]+)"`))
+  return m?.[1] ?? null
+}
+
+function cleanHtml(html: string): string {
+  return html.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()
+}
+
+function decodeEntities(str: string): string {
+  return str
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+}
+
+export function normalizeDate(raw: string | null): string {
+  if (!raw) return todayIso()
+  const d = new Date(raw)
+  if (!isNaN(d.getTime())) return d.toISOString().slice(0, 10)
+  return todayIso()
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10)
+}

--- a/src/lib/goodreadsSyncService.ts
+++ b/src/lib/goodreadsSyncService.ts
@@ -40,7 +40,11 @@ export async function fetchGoodreadsPreview(goodreadsUserId: string): Promise<Sy
   const { data, error } = await supabase.functions.invoke('sync-goodreads', {
     body: { goodreadsUserId },
   })
-  if (error) throw error
+  if (error) {
+    // Extract the actual error message from the response body
+    const body = await (error as any).context?.json?.().catch(() => null)
+    throw new Error(body?.error ?? body?.detail ?? error.message)
+  }
   return (data as { books: SyncPreviewBook[] }).books
 }
 

--- a/src/lib/goodreadsSyncService.ts
+++ b/src/lib/goodreadsSyncService.ts
@@ -1,0 +1,100 @@
+import { supabase } from './supabaseClient'
+import { createLocation } from './locationService'
+import type { Location } from './types'
+
+export interface DetectedLocation {
+  name: string
+  lat: number
+  lng: number
+  isNew: boolean
+  existingId?: string
+}
+
+export interface SyncPreviewBook {
+  goodreads_id: string
+  title: string
+  author: string
+  cover_url: string
+  date_read: string
+  reading_notes: string | null
+  detectedLocation: DetectedLocation | null
+}
+
+export interface SyncPreviewItem extends SyncPreviewBook {
+  skipped: boolean
+  // user-overridden location (null = no location, undefined = use detectedLocation)
+  overrideLocationId?: string | null
+}
+
+const STORAGE_KEY = 'goodreads_user_id'
+
+export function getStoredGoodreadsUserId(): string | null {
+  return localStorage.getItem(STORAGE_KEY)
+}
+
+export function setStoredGoodreadsUserId(id: string): void {
+  localStorage.setItem(STORAGE_KEY, id)
+}
+
+export async function fetchGoodreadsPreview(goodreadsUserId: string): Promise<SyncPreviewBook[]> {
+  const { data, error } = await supabase.functions.invoke('sync-goodreads', {
+    body: { goodreadsUserId },
+  })
+  if (error) throw error
+  return (data as { books: SyncPreviewBook[] }).books
+}
+
+export async function importBooks(
+  items: SyncPreviewItem[],
+  allLocations: Location[]
+): Promise<{ booksImported: number; locationsCreated: number }> {
+  const toImport = items.filter((item) => !item.skipped)
+  if (toImport.length === 0) return { booksImported: 0, locationsCreated: 0 }
+
+  // Collect new locations to create (deduplicated by name)
+  const newLocationNames = new Map<string, DetectedLocation>()
+  for (const item of toImport) {
+    const loc = resolvedLocation(item)
+    if (loc?.isNew) newLocationNames.set(loc.name, loc)
+  }
+
+  // Create new locations first, build name → id map
+  const createdLocationIds = new Map<string, string>()
+  for (const [name, loc] of newLocationNames) {
+    const created = await createLocation(name, loc.lat, loc.lng)
+    createdLocationIds.set(name, created.id)
+  }
+
+  // Build final location_id per item
+  const resolveId = (item: SyncPreviewItem): string | null => {
+    if (item.overrideLocationId !== undefined) return item.overrideLocationId
+    const loc = item.detectedLocation
+    if (!loc) return null
+    if (loc.isNew) return createdLocationIds.get(loc.name) ?? null
+    return loc.existingId ?? null
+  }
+
+  // Insert books
+  const toInsert = toImport.map((item) => ({
+    title: item.title,
+    author: item.author,
+    cover_url: item.cover_url || null,
+    reading_notes: item.reading_notes,
+    read_date: item.date_read,
+    goodreads_id: item.goodreads_id,
+    location_id: resolveId(item),
+  }))
+
+  const { data: insertedBooks, error: bookErr } = await supabase
+    .from('books')
+    .insert(toInsert)
+    .select('id')
+  if (bookErr) throw bookErr
+
+  return { booksImported: (insertedBooks ?? []).length, locationsCreated: createdLocationIds.size }
+}
+
+function resolvedLocation(item: SyncPreviewItem): DetectedLocation | null {
+  if (item.overrideLocationId !== undefined) return null
+  return item.detectedLocation
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -55,6 +55,7 @@ export interface Book {
   cover_url: string | null
   reading_notes: string | null
   read_date: string | null
+  goodreads_id: string | null
   created_at: string
   location_id: string | null
   location?: Location

--- a/supabase/functions/sync-goodreads/index.ts
+++ b/supabase/functions/sync-goodreads/index.ts
@@ -1,8 +1,5 @@
-import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-import Anthropic from 'https://esm.sh/@anthropic-ai/sdk@0.36.3'
-// Shared parser (path relative to project root via import map or inline copy)
-// Because Deno edge functions can't import from src/, the parsing logic is inlined below.
+import { createClient } from 'npm:@supabase/supabase-js@2'
+import Anthropic from 'npm:@anthropic-ai/sdk'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -118,7 +115,7 @@ async function geocode(locationName: string): Promise<{ lat: number; lng: number
 
 // --- Main handler ---
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
   }

--- a/supabase/functions/sync-goodreads/index.ts
+++ b/supabase/functions/sync-goodreads/index.ts
@@ -128,11 +128,16 @@ Deno.serve(async (req) => {
       })
     }
 
-    const rssRes = await fetch(
-      `https://www.goodreads.com/review/list_rss/${goodreadsUserId}?shelf=read&sort=date_read&order=d`
-    )
+    const rssUrl = `https://www.goodreads.com/review/list_rss/${goodreadsUserId}?shelf=read&sort=date_read&order=d`
+    console.log('Fetching RSS:', rssUrl)
+    const rssRes = await fetch(rssUrl, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; ZhaoHuaXiShi/1.0)' }
+    })
+    console.log('RSS status:', rssRes.status)
     if (!rssRes.ok) {
-      return new Response(JSON.stringify({ error: 'Failed to fetch Goodreads RSS' }), {
+      const body = await rssRes.text()
+      console.error('RSS error body:', body.slice(0, 300))
+      return new Response(JSON.stringify({ error: `Goodreads RSS returned ${rssRes.status}`, detail: body.slice(0, 200) }), {
         status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       })
     }
@@ -162,39 +167,38 @@ Deno.serve(async (req) => {
 
     const anthropic = new Anthropic({ apiKey: Deno.env.get('ANTHROPIC_API_KEY')! })
 
-    const results: GoodreadsBook[] = await Promise.all(
-      newBooks.map(async (book) => {
-        const locationName = await detectLocation(book.description, anthropic)
-        let detectedLocation: DetectedLocation | null = null
+    const results: GoodreadsBook[] = []
+    for (const book of newBooks) {
+      const locationName = await detectLocation(book.description, anthropic)
+      let detectedLocation: DetectedLocation | null = null
 
-        if (locationName) {
-          const existingId = locationMap.get(locationName.toLowerCase())
-          if (existingId) {
-            detectedLocation = { name: locationName, lat: 0, lng: 0, isNew: false, existingId }
-          } else {
-            const coords = await geocode(locationName)
-            if (coords) detectedLocation = { name: locationName, ...coords, isNew: true }
-          }
+      if (locationName) {
+        const existingId = locationMap.get(locationName.toLowerCase())
+        if (existingId) {
+          detectedLocation = { name: locationName, lat: 0, lng: 0, isNew: false, existingId }
+        } else {
+          const coords = await geocode(locationName)
+          if (coords) detectedLocation = { name: locationName, ...coords, isNew: true }
         }
+      }
 
-        return {
-          goodreads_id: book.goodreads_id,
-          title: book.title,
-          author: book.author,
-          cover_url: book.cover_url,
-          date_read: book.date_read,
-          reading_notes: book.reading_notes,
-          detectedLocation,
-        }
+      results.push({
+        goodreads_id: book.goodreads_id,
+        title: book.title,
+        author: book.author,
+        cover_url: book.cover_url,
+        date_read: book.date_read,
+        reading_notes: book.reading_notes,
+        detectedLocation,
       })
-    )
+    }
 
     return new Response(JSON.stringify({ books: results }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     })
   } catch (err) {
-    console.error(err)
-    return new Response(JSON.stringify({ error: String(err) }), {
+    console.error('Unhandled error:', err)
+    return new Response(JSON.stringify({ error: String(err), stack: err instanceof Error ? err.stack : undefined }), {
       status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     })
   }

--- a/supabase/functions/sync-goodreads/index.ts
+++ b/supabase/functions/sync-goodreads/index.ts
@@ -1,0 +1,204 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import Anthropic from 'https://esm.sh/@anthropic-ai/sdk@0.36.3'
+// Shared parser (path relative to project root via import map or inline copy)
+// Because Deno edge functions can't import from src/, the parsing logic is inlined below.
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+export interface DetectedLocation {
+  name: string
+  lat: number
+  lng: number
+  isNew: boolean
+  existingId?: string
+}
+
+export interface GoodreadsBook {
+  goodreads_id: string
+  title: string
+  author: string
+  cover_url: string
+  date_read: string
+  reading_notes: string | null
+  detectedLocation: DetectedLocation | null
+}
+
+interface RawBook {
+  goodreads_id: string
+  title: string
+  author: string
+  cover_url: string
+  date_read: string
+  reading_notes: string | null
+  description: string
+}
+
+// --- Inlined parser (mirrors src/lib/goodreadsRssParser.ts) ---
+
+function parseGoodreadsRss(xml: string): RawBook[] {
+  const items = xml.match(/<item>([\s\S]*?)<\/item>/g) ?? []
+  return items.map(parseItem).filter((b): b is RawBook => b !== null)
+}
+
+function parseItem(item: string): RawBook | null {
+  const goodreads_id = extractTag(item, 'book_id') ?? extractAttr(item, 'guid')
+  const title = decodeEntities(extractTag(item, 'title') ?? '')
+  const author = decodeEntities(extractTag(item, 'author_name') ?? '')
+  const cover_url = extractTag(item, 'book_image_url') ?? extractTag(item, 'image_url') ?? ''
+  const date_read_raw = extractTag(item, 'user_date_read') ?? null
+  const reading_notes = cleanHtml(extractTag(item, 'user_review') ?? '') || null
+  const description = cleanHtml(
+    extractCdata(item, 'book_description') ?? extractTag(item, 'description') ?? ''
+  )
+  if (!goodreads_id || !title) return null
+  return { goodreads_id, title, author, cover_url, date_read: normalizeDate(date_read_raw), reading_notes, description }
+}
+
+function extractTag(xml: string, tag: string): string | null {
+  const m =
+    xml.match(new RegExp(`<${tag}[^>]*><!\\[CDATA\\[([\\s\\S]*?)\\]\\]><\\/${tag}>`, 'i')) ??
+    xml.match(new RegExp(`<${tag}[^>]*>([^<]*)<\\/${tag}>`, 'i'))
+  return m?.[1]?.trim() ?? null
+}
+
+function extractCdata(xml: string, tag: string): string | null {
+  const m = xml.match(new RegExp(`<${tag}[^>]*><!\\[CDATA\\[([\\s\\S]*?)\\]\\]><\\/${tag}>`, 'i'))
+  return m?.[1]?.trim() ?? null
+}
+
+function extractAttr(xml: string, attr: string): string | null {
+  return xml.match(new RegExp(`${attr}="([^"]+)"`))?.[1] ?? null
+}
+
+function cleanHtml(html: string): string {
+  return html.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()
+}
+
+function decodeEntities(str: string): string {
+  return str.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#39;/g, "'")
+}
+
+function normalizeDate(raw: string | null): string {
+  if (!raw) return new Date().toISOString().slice(0, 10)
+  const d = new Date(raw)
+  return isNaN(d.getTime()) ? new Date().toISOString().slice(0, 10) : d.toISOString().slice(0, 10)
+}
+
+// --- Location detection ---
+
+async function detectLocation(description: string, anthropic: Anthropic): Promise<string | null> {
+  if (!description || description.length < 20) return null
+  const msg = await anthropic.messages.create({
+    model: 'claude-haiku-4-5',
+    max_tokens: 64,
+    messages: [{
+      role: 'user',
+      content: `Given this book description, identify the PRIMARY real-world location where the story takes place or that the book is primarily about (a specific city, region, or country). Return ONLY the location name (e.g. "Kabul", "Tokyo", "France"), or return null if the book has no clear real-world setting.\n\nDescription: ${description.slice(0, 800)}\n\nLocation (or null):`,
+    }],
+  })
+  const text = (msg.content[0] as { type: string; text: string }).text.trim()
+  if (!text || text.toLowerCase() === 'null' || text.toLowerCase() === 'none') return null
+  return text.replace(/^["']|["']$/g, '')
+}
+
+async function geocode(locationName: string): Promise<{ lat: number; lng: number } | null> {
+  const res = await fetch(
+    `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(locationName)}&format=json&limit=1`,
+    { headers: { 'User-Agent': 'ZhaoHuaXiShi/1.0' } }
+  )
+  if (!res.ok) return null
+  const data = await res.json()
+  if (!data.length) return null
+  return { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon) }
+}
+
+// --- Main handler ---
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const { goodreadsUserId } = await req.json()
+    if (!goodreadsUserId) {
+      return new Response(JSON.stringify({ error: 'goodreadsUserId required' }), {
+        status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
+    const rssRes = await fetch(
+      `https://www.goodreads.com/review/list_rss/${goodreadsUserId}?shelf=read&sort=date_read&order=d`
+    )
+    if (!rssRes.ok) {
+      return new Response(JSON.stringify({ error: 'Failed to fetch Goodreads RSS' }), {
+        status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
+    const rawBooks = parseGoodreadsRss(await rssRes.text())
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    )
+
+    const { data: existingRows } = await supabase
+      .from('books').select('goodreads_id').not('goodreads_id', 'is', null)
+    const existingIds = new Set((existingRows ?? []).map((r: any) => r.goodreads_id as string))
+    const newBooks = rawBooks.filter((b) => !existingIds.has(b.goodreads_id))
+
+    if (newBooks.length === 0) {
+      return new Response(JSON.stringify({ books: [] }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
+    const { data: existingLocations } = await supabase.from('locations').select('id, name')
+    const locationMap = new Map<string, string>(
+      (existingLocations ?? []).map((l: any) => [l.name.toLowerCase(), l.id])
+    )
+
+    const anthropic = new Anthropic({ apiKey: Deno.env.get('ANTHROPIC_API_KEY')! })
+
+    const results: GoodreadsBook[] = await Promise.all(
+      newBooks.map(async (book) => {
+        const locationName = await detectLocation(book.description, anthropic)
+        let detectedLocation: DetectedLocation | null = null
+
+        if (locationName) {
+          const existingId = locationMap.get(locationName.toLowerCase())
+          if (existingId) {
+            detectedLocation = { name: locationName, lat: 0, lng: 0, isNew: false, existingId }
+          } else {
+            const coords = await geocode(locationName)
+            if (coords) detectedLocation = { name: locationName, ...coords, isNew: true }
+          }
+        }
+
+        return {
+          goodreads_id: book.goodreads_id,
+          title: book.title,
+          author: book.author,
+          cover_url: book.cover_url,
+          date_read: book.date_read,
+          reading_notes: book.reading_notes,
+          detectedLocation,
+        }
+      })
+    )
+
+    return new Response(JSON.stringify({ books: results }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  } catch (err) {
+    console.error(err)
+    return new Response(JSON.stringify({ error: String(err) }), {
+      status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  }
+})


### PR DESCRIPTION
## Parent PRD

#38

## Closes

Closes #39, Closes #40, Closes #41, Closes #42, Closes #43

## Summary

- **DB schema** (`#39`): `books.goodreads_id TEXT` 列 + `getExistingGoodreadsIds()` 查询函数
- **Edge Function** (`#40` + `#41`): `supabase/functions/sync-goodreads` — 拉取 Goodreads RSS，过滤已导入书籍，调用 Claude Haiku 识别故事发生地，Nominatim 查坐标，返回完整预览数据
- **RSS 解析模块** (`#40`): `src/lib/goodreadsRssParser.ts` — 纯函数，14 个单元测试全绿
- **前端 Service** (`#42`): `goodreadsSyncService.ts` — 封装 Edge Function 调用和批量写入逻辑
- **同步 UI** (`#42` + `#43`): 书架页「同步 Goodreads」按钮 + `GoodreadsSyncSheet` 底部抽屉，含预览列表、地点选择器（可改/可置空）、新建地点坐标显示、单行跳过、批量导入、完成 toast

## 部署前必须

1. 在 Supabase SQL Editor 执行：
```sql
ALTER TABLE books ADD COLUMN goodreads_id TEXT;
CREATE UNIQUE INDEX books_goodreads_id_idx ON books (goodreads_id) WHERE goodreads_id IS NOT NULL;
```

2. 在 Supabase Edge Function secrets 添加：
```
ANTHROPIC_API_KEY=sk-ant-...
```

3. 部署 Edge Function：
```bash
supabase functions deploy sync-goodreads
```

## Test plan

- [ ] 书架页右上角显示「同步 Goodreads」按钮
- [ ] 首次点击弹出 user ID 输入框，填入后开始同步
- [ ] 再次点击直接开始同步（user ID 已记住）
- [ ] loading 状态可见
- [ ] 预览列表显示封面、书名、作者、日期、检测到的地点
- [ ] 新建地点显示坐标（用于核查 Nominatim 是否选错城市）
- [ ] 地点下拉选择器可修改或置空
- [ ] 单行「跳过」按钮有效
- [ ] 「导入 N 本书」点击后批量写入，完成后 toast
- [ ] 已导入书籍再次同步时不重复出现
- [ ] 无新书时提示「已是最新」

🤖 Generated with [Claude Code](https://claude.com/claude-code)